### PR TITLE
Added support for high contrast map tiles

### DIFF
--- a/__tests__/Home/__snapshots__/Home.react-test.js.snap
+++ b/__tests__/Home/__snapshots__/Home.react-test.js.snap
@@ -167,7 +167,7 @@ exports[`Home component should render as expected 1`] = `
             values={Object {}}
           />
         </h2>
-        <OverviewMap
+        <Connect(OverviewMap)
           enablePopups={true}
           hearings={
             Array [
@@ -205,7 +205,6 @@ exports[`Home component should render as expected 1`] = `
               },
             ]
           }
-          showOnCarousel={false}
           style={
             Object {
               "height": 600,

--- a/__tests__/map-test.js
+++ b/__tests__/map-test.js
@@ -1,0 +1,29 @@
+import { getCorrectContrastMapTileUrl } from '../src/utils/map';
+
+describe('src/utils/map', () => {
+  describe('Returns normal map tiles', () => {
+    test('when high contrast mode is not enabled', () => {
+      const isHighContrastModeEnabled = false;
+      const normalMapTileUrl = "normal url";
+      const highContrastMapTileUrl = "high contrast url";
+      expect(getCorrectContrastMapTileUrl(
+        normalMapTileUrl, highContrastMapTileUrl, isHighContrastModeEnabled)).toBe(normalMapTileUrl);
+    });
+    test('when high contrast map tile url doesnt exist', () => {
+      const isHighContrastModeEnabled = true;
+      const normalMapTileUrl = "normal url";
+      const highContrastMapTileUrl = undefined;
+      expect(getCorrectContrastMapTileUrl(
+        normalMapTileUrl, highContrastMapTileUrl, isHighContrastModeEnabled)).toBe(normalMapTileUrl);
+    });
+  });
+  describe('Returns high contrast map tiles', () => {
+    test('when high contrast mode is enabled and high contrast map tile url exists', () => {
+      const isHighContrastModeEnabled = true;
+      const normalMapTileUrl = "normal url";
+      const highContrastMapTileUrl = "high contrast url";
+      expect(getCorrectContrastMapTileUrl(
+        normalMapTileUrl, highContrastMapTileUrl, isHighContrastModeEnabled)).toBe(highContrastMapTileUrl);
+    });
+  });
+});

--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -5,6 +5,7 @@ import {getHearingURL} from '../utils/hearing';
 import getAttr from '../utils/getAttr';
 import Leaflet, { LatLng } from 'leaflet';
 import { Polygon, Marker, Polyline, Map, TileLayer, FeatureGroup, Popup, GeoJSON } from 'react-leaflet';
+import { connect } from 'react-redux';
 
 import leafletMarkerIconUrl from '../../assets/images/leaflet/marker-icon.png';
 import leafletMarkerRetinaIconUrl from '../../assets/images/leaflet/marker-icon-2x.png';
@@ -12,6 +13,7 @@ import leafletMarkerShadowUrl from '../../assets/images/leaflet/marker-shadow.pn
 /* eslint-disable import/no-unresolved */
 import localization from '@city-i18n/localization.json';
 import urls from '@city-assets/urls.json';
+import { getCorrectContrastMapTileUrl } from '../utils/map';
 /* eslint-enable import/no-unresolved */
 
 class OverviewMap extends React.Component {
@@ -133,7 +135,8 @@ class OverviewMap extends React.Component {
       this.shouldMapRender() &&
       <Map center={localization.mapPosition} zoom={10} style={{ ...this.state }} minZoom={8} scrollWheelZoom={false}>
         <TileLayer
-          url={urls.rasterMapTiles}
+          url={getCorrectContrastMapTileUrl(urls.rasterMapTiles,
+            urls.highContrastRasterMapTiles, this.props.isHighContrast)}
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         />
         <FeatureGroup
@@ -151,6 +154,10 @@ class OverviewMap extends React.Component {
   }
 }
 
+const mapStateToProps = (state) => ({
+  isHighContrast: state.accessibility.isHighContrast,
+});
+
 OverviewMap.propTypes = {
   hearings: PropTypes.array.isRequired,
   style: PropTypes.object,
@@ -158,6 +165,7 @@ OverviewMap.propTypes = {
   enablePopups: PropTypes.bool,
   showOnCarousel: PropTypes.bool,
   mapContainer: PropTypes.object,
+  isHighContrast: PropTypes.bool,
 };
 
 OverviewMap.contextTypes = {
@@ -169,4 +177,4 @@ OverviewMap.defaultProps = {
   mapContainer: undefined,
 };
 
-export default OverviewMap;
+export default connect(mapStateToProps, null)(OverviewMap);

--- a/src/components/admin/HearingFormStep3.js
+++ b/src/components/admin/HearingFormStep3.js
@@ -10,6 +10,7 @@ import {isEmpty, includes, keys} from 'lodash';
 import {ZoomControl} from 'react-leaflet';
 import {localizedNotifyError} from '../../utils/notify';
 import Icon from '../../utils/Icon';
+import { connect } from 'react-redux';
 
 import leafletMarkerIconUrl from '../../../assets/images/leaflet/marker-icon.png';
 import leafletMarkerRetinaIconUrl from '../../../assets/images/leaflet/marker-icon-2x.png';
@@ -20,6 +21,7 @@ import urls from '@city-assets/urls.json';
 /* eslint-enable import/no-unresolved */
 
 import {hearingShape} from '../../types';
+import { getCorrectContrastMapTileUrl } from '../../utils/map';
 
 // This is needed for the invalidateMap not to fire after the component has dismounted and causing error.
 let mapInvalidator;
@@ -228,7 +230,8 @@ class HearingFormStep3 extends React.Component {
             <ZoomControl zoomInTitle="Lähennä" zoomOutTitle="Loitonna"/>
             <TileLayer
               attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-              url={urls.rasterMapTiles}
+              url={getCorrectContrastMapTileUrl(urls.rasterMapTiles,
+                urls.highContrastRasterMapTiles, this.props.isHighContrast)}
             />
             <FeatureGroup ref={(group) => { this.featureGroup = group; }}>
               <EditControl
@@ -268,14 +271,19 @@ class HearingFormStep3 extends React.Component {
   }
 }
 
+const mapStateToProps = (state) => ({
+  isHighContrast: state.accessibility.isHighContrast,
+});
+
 HearingFormStep3.propTypes = {
   hearing: hearingShape,
   onContinue: PropTypes.func,
   onHearingChange: PropTypes.func,
   visible: PropTypes.bool,
-  language: PropTypes.string
+  language: PropTypes.string,
+  isHighContrast: PropTypes.bool,
 };
 
-const WrappedHearingFormStep3 = injectIntl(HearingFormStep3);
+const WrappedHearingFormStep3 = connect(mapStateToProps, null)(injectIntl(HearingFormStep3));
 
 export default WrappedHearingFormStep3;

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -15,3 +15,18 @@ export function EPSG3067() { // eslint-disable-line
   };
   return new L.Proj.CRS(crsName, projDef, crsOpts);
 }
+
+/**
+ * Returns high contrast map tiles url if the url exists and if high contrast setting is on,
+ * otherwise returns normal map tiles url.
+ * @param {string} normalMapTilesUrl
+ * @param {string} highContrastMapTilesUrl
+ * @param {boolean} isHighContrastEnabled
+ */
+export function getCorrectContrastMapTileUrl(normalMapTilesUrl, highContrastMapTilesUrl, isHighContrastEnabled) {
+  if (isHighContrastEnabled && highContrastMapTilesUrl) {
+    return highContrastMapTilesUrl;
+  }
+
+  return normalMapTilesUrl;
+}


### PR DESCRIPTION
High contrast map tiles can be toggled via the contrast button/setting.

A new url "highContrastRasterMapTiles" needs to be added for the high contrast map tiles in city settings /assets/urls.json. Without the high contrast map tiles url, normal map tiles are always used.