### PR TITLE
Ignore tracking code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ bower_components
 /config_dev.toml
 
 /assets/plugins
+
+/assets/js/tracker


### PR DESCRIPTION
Project/city specific tracking code such as matomo and piwik can be placed under /assets/js/tracker without it being tracked by git.