### PR TITLE
language-switcher rework

### DIFF
--- a/__tests__/LanguageSwitcher-test.js
+++ b/__tests__/LanguageSwitcher-test.js
@@ -1,0 +1,155 @@
+import React from 'react';
+
+import {UnconnectedLanguageSwitcher} from "../src/components/Header/LanguageSwitcher";
+import { Button } from "react-bootstrap";
+import { shallow } from 'enzyme';
+import getMessage from "../src/utils/getMessage";
+import Icon from "../src/utils/Icon";
+import config from "../src/config";
+
+const defaults = {
+  currentLanguage: 'fi'
+};
+const classWhenFalse = 'dropdown btn-group';
+const classWhenTrue = 'dropdown open btn-group';
+describe('src/components/Header/LanguageSwitcherV2', () => {
+  function getWrapper(props) {
+    return shallow(<UnconnectedLanguageSwitcher {...defaults} {...props}/>);
+  }
+
+  describe('changeLanguage', () => {
+    test('is called when changing language', () => {
+      const changeLanguageMock = jest.fn();
+      const element = getWrapper();
+      element.instance().changeLanguage = changeLanguageMock;
+      element.instance().forceUpdate();
+      const instance = element.instance();
+      const spy = jest.spyOn(instance, 'changeLanguage');
+      element.find('a').at(0).simulate('click', {preventDefault: () => {}});
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('handle functions', () => {
+    test('handleClick', () => {
+      const handleClickMock = jest.fn();
+      const element = getWrapper();
+      element.instance().handleClick = handleClickMock;
+      element.instance().forceUpdate();
+      const instance = element.instance();
+      const spy = jest.spyOn(instance, 'handleClick');
+      instance.handleClick();
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleDropdown', () => {
+    test('toggles state.openDropdown', () => {
+      const element = getWrapper();
+      const instance = element.instance();
+      expect(element.state('openDropdown')).toBe(false);
+      instance.toggleDropdown();
+      expect(element.state('openDropdown')).toBe(true);
+    });
+  });
+
+  describe('render', () => {
+    describe('top div container', () => {
+      test('has correct classNames when state.openDropdown is false', () => {
+        const element = getWrapper().find('div');
+        expect(element.prop('className')).toEqual(classWhenFalse);
+      });
+
+      test('has correct classNames when state.openDropdown is true', () => {
+        const element = getWrapper().setState({openDropdown: true}).find('div');
+        expect(element.prop('className')).toEqual(classWhenTrue);
+      });
+    });
+
+    describe('Button', () => {
+      test('has correct props', () => {
+        const element = getWrapper().find(Button);
+        expect(element.prop('className')).toBe('language-switcher');
+        expect(element.prop('onClick')).toBeDefined();
+        expect(element.prop('aria-label')).toBe(getMessage('languageSwitchLabel'));
+        expect(element.prop('id')).toBe('language');
+      });
+
+      describe('has correct child', () => {
+        test('Icon', () => {
+          const element = getWrapper().find(Button).find(Icon);
+          expect(element).toHaveLength(1);
+          expect(element.prop('name')).toBe('globe');
+          expect(element.prop('className')).toBe('user-nav-icon');
+          expect(element.prop('aria-hidden')).toBe('true');
+        });
+
+        test('text for currentLanguage', () => {
+          const element = getWrapper().find(Button).find('span').at(0);
+          expect(element.text()).toContain(defaults.currentLanguage);
+        });
+      });
+
+      describe('onClick', () => {
+        test('works and changes div container className', () => {
+          const element = getWrapper();
+          expect(element.find('div').prop('className')).toBe(classWhenFalse);
+          element.find(Button).at(0).simulate('click');
+          expect(element.find('div').prop('className')).toBe(classWhenTrue);
+          element.find(Button).at(0).simulate('click');
+          expect(element.find('div').prop('className')).toBe(classWhenFalse);
+        });
+      });
+    });
+
+    describe('ul element', () => {
+      const languages = config.languages;
+      function getUL(props) {
+        return getWrapper(props).find('ul');
+      }
+
+      test('with correct props', () => {
+        const element = getUL();
+        expect(element.prop('className')).toBe('dropdown-menu dropdown-menu-right');
+        expect(element.prop('aria-labelledby')).toBe('language');
+      });
+
+      describe('li elements', () => {
+        const element = getUL().find('li');
+        test('amount according to config.languages', () => {
+          const correctAmount = languages.length;
+          expect(element).toHaveLength(correctAmount);
+        });
+
+        test('with correct className if currentLanguage', () => {
+          const elementSV = getWrapper({currentLanguage: languages[1]}).find('li').at(1);
+          expect(elementSV.hasClass('active')).toBe(true);
+        });
+
+        describe('a elements', () => {
+          function getLinkAs(props) {
+            return getWrapper(props).find('ul').find('li').find('a');
+          }
+
+          test('with correct props', () => {
+            const aElements = getLinkAs().at(0);
+            const first = aElements;
+            expect(first.prop('href')).toBe('#');
+            expect(first.prop('aria-label')).toBe(getMessage(`lang-${languages[0]}`));
+            expect(first.prop('onClick')).toBeDefined();
+          });
+
+          test('with correct texts', () => {
+            const aElements = getLinkAs();
+            const first = aElements.at(0);
+            const second = aElements.at(1);
+            expect(first.text()).toBe(getMessage(`lang-${languages[0]}`));
+            expect(second.text()).toBe(getMessage(`lang-${languages[1]}`));
+          });
+        });
+      });
+    });
+  });
+});

--- a/assets/sass/kerrokantasi/_navigation.scss
+++ b/assets/sass/kerrokantasi/_navigation.scss
@@ -50,8 +50,23 @@
   }
 }
 
+.dropdown.btn-group > a {
+  text-transform: uppercase;
+  color: #333;
+  padding: 6px 12px;
+  &:hover, &:focus {
+    text-decoration: none;
+  }
+}
+.dropdown-menu.open {
+  display: block;
+}
+
 .language-switcher {
   text-transform: uppercase;
+  span.caret {
+    margin-left: 5px;
+  }
 
   &.active > a:after{
     display: none;

--- a/src/components/Header/LanguageSwitcher.js
+++ b/src/components/Header/LanguageSwitcher.js
@@ -1,49 +1,103 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {DropdownButton, MenuItem} from 'react-bootstrap';
 import Icon from '../../utils/Icon';
-import {connect} from 'react-redux';
-import {intlShape} from 'react-intl';
+import { connect } from 'react-redux';
+import { Button} from "react-bootstrap";
 import config from '../../config';
-import {withRouter} from 'react-router-dom';
-import { stringifyQuery } from '../../utils/urlQuery';
+import { withRouter} from "react-router-dom";
+import { stringifyQuery} from "../../utils/urlQuery";
 
-const changeLang = (history, location, nextLang) => {
-  history.push({
-    path: location.pathname,
-    search: stringifyQuery({ lang: nextLang })
-  });
-};
 
-const LanguageSwitcher = ({currentLanguage, location, history}, {intl: {formatMessage}}) =>
-  <DropdownButton
-    pullRight
-    className="language-switcher"
-    id="language"
-    title={<span><Icon name="globe" className="user-nav-icon" aria-hidden="true"/>{currentLanguage} </span>}
-    aria-label={formatMessage({id: 'languageSwitchLabel'})}
-  >
-    {config.languages
-      .map((code) =>
-        <MenuItem
-          href=""
-          key={code}
-          className="language-switcher__language"
-          onClick={() => changeLang(history, location, code)}
-          active={code === currentLanguage}
+import getMessage from "../../utils/getMessage";
+import classNames from 'classnames';
+
+class LanguageSwitcher extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      openDropdown: false,
+    };
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleClick, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClick, false);
+  }
+
+  changeLanguage(history, location, nextLang) {
+    history.push({
+      path: location.pathname,
+      search: stringifyQuery({ lang: nextLang })
+    });
+
+    this.toggleDropdown();
+  }
+
+  handleClick = (e) => {
+    if (!this.node.contains(e.target)) {
+      this.handleOutsideClick();
+    }
+  }
+
+  handleOutsideClick() {
+    if (this.state.openDropdown) {
+      this.setState({openDropdown: false});
+    }
+  }
+
+  toggleDropdown() {
+    this.setState({openDropdown: !this.state.openDropdown});
+  }
+
+  getMenuItem(history, location, code) {
+    const { currentLanguage } = this.props;
+    return (
+      <li key={code} className={classNames({active: code === currentLanguage})}>
+        <a
+          href="#"
+          aria-label={getMessage(`lang-${code}`)}
+          onClick={(e) => {
+            e.preventDefault();
+            this.changeLanguage(history, location, code);
+          }}
         >
-          {formatMessage({id: `lang-${code}`})}
-        </MenuItem>)}
-  </DropdownButton>;
+          {getMessage(`lang-${code}`)}
+        </a>
+      </li>
+    );
+  }
 
-LanguageSwitcher.contextTypes = {
-  intl: intlShape.isRequired
-};
+  render() {
+    const {currentLanguage, history, location} = this.props;
+    return (
+      <div className={classNames('dropdown', {open: this.state.openDropdown}, 'btn-group')} ref={node => this.node = node} >
+        <Button className="language-switcher" onClick={() => this.toggleDropdown()} aria-label={getMessage('languageSwitchLabel')} id="language">
+          <span>
+            <Icon name="globe" className="user-nav-icon" aria-hidden="true" />
+            {currentLanguage}
+            <span className="caret" />
+          </span>
+        </Button>
+        <ul className={classNames('dropdown-menu dropdown-menu-right')} aria-labelledby="language">
+          { config.languages
+            .map((code) =>
+              this.getMenuItem(history, location, code)
+            )
+          }
+        </ul>
+      </div>
+    );
+  }
+}
+
 
 LanguageSwitcher.propTypes = {
   currentLanguage: PropTypes.string,
   location: PropTypes.object,
   history: PropTypes.object
 };
-
+export { LanguageSwitcher as UnconnectedLanguageSwitcher};
 export default withRouter(connect()(LanguageSwitcher));

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Navbar, Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import Icon from '../../utils/Icon';
+
 import LanguageSwitcher from './LanguageSwitcher';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -112,7 +113,7 @@ class Header extends React.Component {
     if (config.enableHighContrast) {
       return (
         <Button className="contrast-button" onClick={() => this.props.toggleContrast()}>
-          <Icon name="adjust" />
+          <Icon name="adjust" aria-hidden="true"/>
           <FormattedMessage id="contrastTitle">{text => <span className="contrast-title">{text}</span> }</FormattedMessage>
         </Button>
       );
@@ -146,7 +147,7 @@ class Header extends React.Component {
 
               <div className="nav-user-menu navbar-right">
                 {this.contrastToggle()}
-                <LanguageSwitcher currentLanguage={this.props.language} />
+                <LanguageSwitcher currentLanguage={this.props.language}/>
                 {userItems}
               </div>
             </Navbar>


### PR DESCRIPTION
Added a new language-switcher that is fully keyboard navigable/usable that uses the pre-existing css/scss classnames and stylings.