### PR TITLE
specifying focustarget

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -21,6 +21,7 @@ const historySettings = {
   /* eslint-enable */
   announcePageNavigation: false, // default true
   setPageTitle: false,
+  primaryFocusTarget: "body",
 };
 
 wrapHistory(history, historySettings);


### PR DESCRIPTION
specified the primaryFocusTarget so the site moves focus to `<body> `instead of the default first `<h1>` in `<main>` after refresh.