### PR TITLE
fix to pdf attachment size limit

### DIFF
--- a/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
@@ -325,7 +325,7 @@ exports[`HearingContainer component should render as expected 1`] = `
             "eyeTooltipOpensHours": "tunnin kuluttua. Se ei ole vielä julkisesti nähtävissä.",
             "feedbackLinkText": "Palaute",
             "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
-            "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin 70 megatavua.",
+            "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin {n} megatavua.",
             "firstClosing": "Ensimmäisenä sulkeutuva",
             "firstOpen": "Ensimmäisenä auennut",
             "follow": "Seuraa",

--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -118,7 +118,7 @@ exports[`HearingsList component should render as expected 1`] = `
                   "eyeTooltipOpensHours": "tunnin kuluttua. Se ei ole vielä julkisesti nähtävissä.",
                   "feedbackLinkText": "Palaute",
                   "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
-                  "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin 70 megatavua.",
+                  "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin {n} megatavua.",
                   "firstClosing": "Ensimmäisenä sulkeutuva",
                   "firstOpen": "Ensimmäisenä auennut",
                   "follow": "Seuraa",

--- a/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
@@ -178,7 +178,7 @@ exports[`Hearings component should render as expected 1`] = `
           "eyeTooltipOpensHours": "tunnin kuluttua. Se ei ole vielä julkisesti nähtävissä.",
           "feedbackLinkText": "Palaute",
           "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
-          "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin 70 megatavua.",
+          "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin {n} megatavua.",
           "firstClosing": "Ensimmäisenä sulkeutuva",
           "firstOpen": "Ensimmäisenä auennut",
           "follow": "Seuraa",

--- a/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
+++ b/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
@@ -286,7 +286,7 @@ exports[`SortableCommentList component should render as expected 1`] = `
                 "eyeTooltipOpensHours": "tunnin kuluttua. Se ei ole vielä julkisesti nähtävissä.",
                 "feedbackLinkText": "Palaute",
                 "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
-                "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin 70 megatavua.",
+                "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin {n} megatavua.",
                 "firstClosing": "Ensimmäisenä sulkeutuva",
                 "firstOpen": "Ensimmäisenä auennut",
                 "follow": "Seuraa",

--- a/src/components/admin/SectionForm.js
+++ b/src/components/admin/SectionForm.js
@@ -15,14 +15,18 @@ import {
 import Dropzone from 'react-dropzone';
 
 import Icon from '../../utils/Icon';
-import {localizedNotifyError} from '../../utils/notify';
+import {localizedNotifyError, notifyError} from '../../utils/notify';
 import SectionAttachmentEditor from './SectionAttachmentEditor';
 import MultiLanguageTextField, {TextFieldTypes} from '../forms/MultiLanguageTextField';
 import {sectionShape} from '../../types';
 import {isSpecialSectionType} from '../../utils/section';
 
+/**
+ * MAX_IMAGE_SIZE given in bytes
+ * MAX_FILE_SIZE given in MB
+ */
 const MAX_IMAGE_SIZE = 999999;
-const MAX_FILE_SIZE = 999999;
+const MAX_FILE_SIZE = 70;
 
 class SectionForm extends React.Component {
   constructor(props) {
@@ -70,8 +74,13 @@ class SectionForm extends React.Component {
    * @param {File} attachment - file to upload.
    */
   onAttachmentDrop = (attachment) => {
-    if (attachment[0].size > MAX_FILE_SIZE) {
-      localizedNotifyError('fileSizeError');
+    const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE * 1000 * 1000;
+    if (attachment[0].size > MAX_FILE_SIZE_BYTES) {
+      const localizedErrorMessage =
+        <FormattedMessage id="fileSizeError" values={{n: MAX_FILE_SIZE.toString()}}>
+          {text => text}
+        </FormattedMessage>;
+      notifyError(localizedErrorMessage);
       return;
     }
     // Load the file and then upload it.

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -69,7 +69,7 @@
   "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",
   "eyeTooltipOpensHours": "tunnin kuluttua. Se ei ole vielä julkisesti nähtävissä.",
   "feedbackPrompt": "Kerro meille, miten tätä palvelua pitäisi kehittää!",
-  "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin 70 megatavua.",
+  "fileSizeError": "Liitetiedosto on liian suuri. Maksimikoko on noin {n} megatavua.",
   "firstClosing": "Ensimmäisenä sulkeutuva",
   "firstOpen": "Ensimmäisenä auennut",
   "follow": "Seuraa",


### PR DESCRIPTION
The filesize-limit of a pdf is now 70MB, updated error message to display max size according to passed value.