### PR TITLE
fix to comment button being rendered

### DIFF
--- a/src/components/SortableCommentList.js
+++ b/src/components/SortableCommentList.js
@@ -261,7 +261,7 @@ export class SortableCommentListComponent extends Component {
 
     const showCommentList =
       section && sectionComments && get(sectionComments, 'results') && !isEmpty(sectionComments.results);
-    const commentForm = published ? (
+    const commentForm = published && !closed ? (
       <div className="row">
         <div className={classnames("comment-form-container", {disabled: !canComment})}>
           <CommentForm


### PR DESCRIPTION
Commenting button was previously rendered in a disabled state even if the hearing was closed. This fix checks if the hearing is closed, if the hearing is closed then the button wont be rendered at all.