### PR TITLE
Changed iframe copy paste dimension parsing

### DIFF
--- a/__tests__/HearingEditor/Iframes/IframeCopyPasteField-test.js
+++ b/__tests__/HearingEditor/Iframes/IframeCopyPasteField-test.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import IframeCopyPasteField from '../../../src/components/RichTextEditor/Iframe/IframeCopyPasteField';
 import getMessage from '../../../src/utils/getMessage';
-import { parseIframeHtml } from '../../../src/components/RichTextEditor/Iframe//IframeUtils';
+import {
+  parseIframeHtml,
+  convertStyleDimensionSettings
+} from '../../../src/components/RichTextEditor/Iframe//IframeUtils';
 
 
 describe('IframeSelectField', () => {
@@ -55,10 +58,11 @@ describe('IframeSelectField', () => {
       });
       test('calls props.updateAttributes', () => {
         const instance = getWrapper().instance();
-        const event = {target: {value: '<iframe title="test-title"></iframe>'}};
+        const event = {target: {value: '<iframe title="test-title" style="width: 150px;"></iframe>'}};
         instance.handleCopyPasteChange(event);
         expect(defaultProps.updateAttributes.mock.calls.length).toBe(1);
-        expect(defaultProps.updateAttributes.mock.calls[0][0]).toEqual(parseIframeHtml(event.target.value));
+        expect(defaultProps.updateAttributes.mock.calls[0][0])
+          .toEqual(convertStyleDimensionSettings(parseIframeHtml(event.target.value)));
       });
     });
   });

--- a/__tests__/HearingEditor/Iframes/IframeUtils-test.js
+++ b/__tests__/HearingEditor/Iframes/IframeUtils-test.js
@@ -3,6 +3,7 @@ import {
   stripIframeWrapperDivs,
   addIframeWrapperDivs,
   parseIframeHtml,
+  convertStyleDimensionSettings,
   validateIsNotEmpty,
   validateIsNumber,
   IFRAME_VALIDATION,
@@ -53,6 +54,73 @@ describe('IframeUtils', () => {
     test('returns an empty object if input doesnt contain iframe elements', () => {
       const htmlString = '<div><p>text</p><figure></figure></div>';
       expect(parseIframeHtml(htmlString)).toEqual({});
+    });
+  });
+
+  describe('convertStyleDimensionSettings', () => {
+    test('returns attribute object where style dimensions are added as their own object properties', () => {
+      const attributes = {
+        src: "https://google.fi",
+        title: "test",
+        style: "border: none; width: 400px; height: 188px;",
+      };
+      const expectedAttributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "400",
+        height: "188",
+        style: "border: none;",
+      };
+      expect(convertStyleDimensionSettings(attributes)).toEqual(expectedAttributes);
+    });
+    test('replaces current attribute dimension properties with style dimensions', () => {
+      const attributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "200",
+        height: "150",
+        style: "border: none; width: 400px; height: 188px;",
+      };
+      const expectedAttributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "400",
+        height: "188",
+        style: "border: none;",
+      };
+      expect(convertStyleDimensionSettings(attributes)).toEqual(expectedAttributes);
+    });
+    test('converts correctly with only one given style dimension setting', () => {
+      const attributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "200",
+        height: "150",
+        style: "border: none; width: 400px;",
+      };
+      const expectedAttributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "400",
+        height: "150",
+        style: "border: none;",
+      };
+      expect(convertStyleDimensionSettings(attributes)).toEqual(expectedAttributes);
+    });
+    test('returns copy of original attributes if there are no style dimension settings', () => {
+      const attributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "200",
+        style: "border: none;",
+      };
+      const expectedAttributes = {
+        src: "https://google.fi",
+        title: "test",
+        width: "200",
+        style: "border: none;",
+      };
+      expect(convertStyleDimensionSettings(attributes)).toEqual(expectedAttributes);
     });
   });
 

--- a/__tests__/HearingEditor/Iframes/IframeUtils-test.js
+++ b/__tests__/HearingEditor/Iframes/IframeUtils-test.js
@@ -59,19 +59,22 @@ describe('IframeUtils', () => {
 
   describe('convertStyleDimensionSettings', () => {
     test('returns attribute object where style dimensions are added as their own object properties', () => {
-      const attributes = {
+      const attributesA = { title: "test", style: "width: 12px;" };
+      const expectedAttributesA = { title: "test", width: "12", style: "" };
+      const attributesB = {
         src: "https://google.fi",
         title: "test",
         style: "border: none; width: 400px; height: 188px;",
       };
-      const expectedAttributes = {
+      const expectedAttributesB = {
         src: "https://google.fi",
         title: "test",
         width: "400",
         height: "188",
         style: "border: none;",
       };
-      expect(convertStyleDimensionSettings(attributes)).toEqual(expectedAttributes);
+      expect(convertStyleDimensionSettings(attributesA)).toEqual(expectedAttributesA);
+      expect(convertStyleDimensionSettings(attributesB)).toEqual(expectedAttributesB);
     });
     test('replaces current attribute dimension properties with style dimensions', () => {
       const attributes = {

--- a/src/components/RichTextEditor/Iframe/IframeCopyPasteField.js
+++ b/src/components/RichTextEditor/Iframe/IframeCopyPasteField.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import getMessage from '../../../utils/getMessage';
-import { parseIframeHtml } from './IframeUtils';
+import { parseIframeHtml, convertStyleDimensionSettings } from './IframeUtils';
 
 
 class IframeCopyPasteField extends React.Component {
@@ -17,7 +17,10 @@ class IframeCopyPasteField extends React.Component {
   handleCopyPasteChange(event) {
     const {value} = event.target;
     this.setState({htmlCopyPaste: value});
-    const attributes = parseIframeHtml(value);
+
+    // if iframe has width and/or height in the style attribute
+    // convert the dimensions into their own attributes
+    const attributes = convertStyleDimensionSettings(parseIframeHtml(value));
     this.props.updateAttributes(attributes);
   }
 

--- a/src/components/RichTextEditor/Iframe/IframeUtils.js
+++ b/src/components/RichTextEditor/Iframe/IframeUtils.js
@@ -60,8 +60,8 @@ export function convertStyleDimensionSettings(attributes) {
     const width = style.match(widthRegex);
     const height = style.match(heightRegex);
 
-    const widthRemoveRegex = /(?<=;)\s*width:\D*\d+\D*;/gi;
-    const heightRemoveRegex = /(?<=;)\s*height:\D*\d+\D*;/gi;
+    const widthRemoveRegex = /(?<=;|)\s*width:\D*\d+\D*;/gi;
+    const heightRemoveRegex = /(?<=;|)\s*height:\D*\d+\D*;/gi;
     newAttributes.style = style.replace(widthRemoveRegex, '').replace(heightRemoveRegex, '');
 
     if (width) {

--- a/src/components/RichTextEditor/Iframe/IframeUtils.js
+++ b/src/components/RichTextEditor/Iframe/IframeUtils.js
@@ -47,6 +47,34 @@ export function parseIframeHtml(htmlInput) {
   return attributeObject;
 }
 
+// removes width and/or height from attribute style string,
+// adds or replaces attribute width and height properties with removed style values
+// and returns the resulting attribute object.
+export function convertStyleDimensionSettings(attributes) {
+  const newAttributes = {...attributes};
+  if ("style" in newAttributes) {
+    const style = newAttributes.style;
+    const widthRegex = /(?<=width:\D*)(\d+)(?=\D*;)/gi;
+    const heightRegex = /(?<=height:\D*)(\d+)(?=\D*;)/gi;
+
+    const width = style.match(widthRegex);
+    const height = style.match(heightRegex);
+
+    const widthRemoveRegex = /(?<=;)\s*width:\D*\d+\D*;/gi;
+    const heightRemoveRegex = /(?<=;)\s*height:\D*\d+\D*;/gi;
+    newAttributes.style = style.replace(widthRemoveRegex, '').replace(heightRemoveRegex, '');
+
+    if (width) {
+      newAttributes.width = width[0];
+    }
+    if (height) {
+      newAttributes.height = height[0];
+    }
+  }
+
+  return newAttributes;
+}
+
 export function validateIsNotEmpty(value) {
   if (!value || value === '') {
     return false;


### PR DESCRIPTION
When iframe copy-paste html contains style attribute with width and/or height setting, these style dimensions are removed from the style attribute and added directly as iframe dimension attributes. This change prevents possible iframe dimension overwrite problems.