### PR TITLE
Disallowed pasted styles in hearing editor

### DIFF
--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -509,6 +509,7 @@ class RichTextEditor extends React.Component {
           onChange={this.onChange}
           onBlur={this.onBlur}
           onTab={this.onTab}
+          stripPastedStyles
           placeholder={this.getPlaceholder()}
         />
       </div>


### PR DESCRIPTION
Copy pasting styled content in hearing rich text editor will now strip all styles leaving only the plaintext.