### PR TITLE
Added new sub section attachment error handling

### DIFF
--- a/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/HearingContainer.react-test.js.snap
@@ -324,6 +324,7 @@ exports[`HearingContainer component should render as expected 1`] = `
             "editHearing": "Muokkaa",
             "email": "Sähköposti",
             "employee": "Työntekijä",
+            "errorSaveBeforeAttachment": "Tallenna ensin ja palaa sitten lisäämään liitteet",
             "eyeTooltip": "Tätä kuulemista ei ole julkaistu eikä se ole julkisesti nähtävissä.",
             "eyeTooltipOpens": "Tämä kuuleminen julkaistaan",
             "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",

--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -117,6 +117,7 @@ exports[`HearingsList component should render as expected 1`] = `
                   "editHearing": "Muokkaa",
                   "email": "Sähköposti",
                   "employee": "Työntekijä",
+                  "errorSaveBeforeAttachment": "Tallenna ensin ja palaa sitten lisäämään liitteet",
                   "eyeTooltip": "Tätä kuulemista ei ole julkaistu eikä se ole julkisesti nähtävissä.",
                   "eyeTooltipOpens": "Tämä kuuleminen julkaistaan",
                   "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",

--- a/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/Hearings.react-test.js.snap
@@ -177,6 +177,7 @@ exports[`Hearings component should render as expected 1`] = `
           "editHearing": "Muokkaa",
           "email": "Sähköposti",
           "employee": "Työntekijä",
+          "errorSaveBeforeAttachment": "Tallenna ensin ja palaa sitten lisäämään liitteet",
           "eyeTooltip": "Tätä kuulemista ei ole julkaistu eikä se ole julkisesti nähtävissä.",
           "eyeTooltipOpens": "Tämä kuuleminen julkaistaan",
           "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",

--- a/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
+++ b/__tests__/__snapshots__/SortableCommentList.react-test.js.snap
@@ -286,6 +286,7 @@ exports[`SortableCommentList component should render as expected 1`] = `
                 "editHearing": "Muokkaa",
                 "email": "Sähköposti",
                 "employee": "Työntekijä",
+                "errorSaveBeforeAttachment": "Tallenna ensin ja palaa sitten lisäämään liitteet",
                 "eyeTooltip": "Tätä kuulemista ei ole julkaistu eikä se ole julkisesti nähtävissä.",
                 "eyeTooltipOpens": "Tämä kuuleminen julkaistaan",
                 "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",

--- a/src/actions/hearingEditor.js
+++ b/src/actions/hearingEditor.js
@@ -461,9 +461,13 @@ export function addSectionAttachment(section, file, title, isNew) {
       .post(getState(), url, data)
       .then(checkResponseStatus)
       .then((response) => {
-        response.json().then((attachment) => {
-          return dispatch(createAction(EditorActions.ADD_ATTACHMENT)({sectionId: section, attachment}));
-        });
+        if (response.status === 400 && !isNew) {
+          localizedNotifyError('errorSaveBeforeAttachment');
+        } else {
+          response.json().then((attachment) => {
+            return dispatch(createAction(EditorActions.ADD_ATTACHMENT)({sectionId: section, attachment}));
+          });
+        }
       });
   };
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -58,6 +58,7 @@
   "editContact": "Edit contact",
   "email": "Email",
   "employee": "Employee",
+  "errorSaveBeforeAttachment": "Save first and then return to add attachments",
   "feedbackLinkText": "Feedback",
   "feedbackPrompt": "Please give us feedback on how to improve the service!",
   "firstClosing": "Closing first",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -75,6 +75,7 @@
   "editHearing": "Muokkaa",
   "email": "Sähköposti",
   "employee": "Työntekijä",
+  "errorSaveBeforeAttachment": "Tallenna ensin ja palaa sitten lisäämään liitteet",
   "eyeTooltip": "Tätä kuulemista ei ole julkaistu eikä se ole julkisesti nähtävissä.",
   "eyeTooltipOpens": "Tämä kuuleminen julkaistaan",
   "eyeTooltipOpensDays": "päivän kuluttua. Se ei ole vielä julkisesti nähtävissä.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -54,6 +54,7 @@
   "edit": "Redigera",
   "editContact": "Redigera kontakten",
   "email": "E-post",
+  "errorSaveBeforeAttachment": "Spara först hörandet och lägg sedan till bilagorna",
   "feedbackLinkText": "Feedback",
   "feedbackPrompt": "Berätta för oss hur den här tjänsten borde utvecklas!",
   "firstClosing": "Den som stängs först",


### PR DESCRIPTION
Added a new error message when attempting to add attachments to a new sub section when the main hearing isn't new.