### PR TITLE
hotfix to ensure that cookiebot blocks cookies

### DIFF
--- a/src/utils/cookieUtils.js
+++ b/src/utils/cookieUtils.js
@@ -53,8 +53,9 @@ export function getConsentScripts() {
 export function getCookieScripts() {
   return (
     <script
-      type="text/javascript"
+      type="text/plain"
       src={urls.analytics}
+      data-cookieconsent="statistics"
     >
     </script>
   );


### PR DESCRIPTION
Changes:
- changed cookie script tag to ensure that cookiebot works correctly. For some reason Cookiebot didn't automatically block this script after declining cookies so this change is to make sure that Cookiebot sees/blocks the script.