### PR TITLE
32-fixed issue with not being able to comment with answers after deleting previously added comment

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -378,7 +378,15 @@ export function editSectionComment(hearingSlug, sectionId, commentId, commentDat
   };
 }
 
-export function deleteSectionComment(hearingSlug, sectionId, commentId) {
+/**
+ * Delete a specific comment
+ * @param {String} hearingSlug
+ * @param {String} sectionId
+ * @param {Number} commentId
+ * @param {Boolean} [refreshUser=false] Determines if userdata is updated after comment deletion
+ * @returns {function(*, *): *}
+ */
+export function deleteSectionComment(hearingSlug, sectionId, commentId, refreshUser = false) {
   return (dispatch, getState) => {
     const fetchAction = createAction("postingComment")({hearingSlug, sectionId});
     dispatch(fetchAction);
@@ -388,6 +396,8 @@ export function deleteSectionComment(hearingSlug, sectionId, commentId) {
       dispatch(createAction("postedComment")({sectionId}));
       // we must update hearing comment count
       dispatch(fetchHearing(hearingSlug));
+      // update user answered questions if refreshUser is true
+      if (refreshUser) { dispatch(retrieveUserFromSession()); }
       localizedAlert("commentDeleted");
     }).catch(requestErrorHandler());
   };

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -94,8 +94,9 @@ class Comment extends React.Component {
   handleDelete(event) {
     event.preventDefault();
     const {data} = this.props;
-    const {section, id} = data;
-    this.props.onDeleteComment(section, id);
+    const {section, id, answers} = data;
+    // userdata is updated if the comment contained answers
+    this.props.onDeleteComment(section, id, answers.length > 0);
   }
 
   /**

--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -163,9 +163,9 @@ export class SectionContainerComponent extends React.Component {
 
   onDeleteComment = () => {
     const {match} = this.props;
-    const {sectionId, commentId} = this.state.commentToDelete;
+    const {sectionId, commentId, refreshUser} = this.state.commentToDelete;
     const hearingSlug = match.params.hearingSlug;
-    this.props.deleteSectionComment(hearingSlug, sectionId, commentId);
+    this.props.deleteSectionComment(hearingSlug, sectionId, commentId, refreshUser);
     this.forceUpdate();
   }
 
@@ -187,8 +187,8 @@ export class SectionContainerComponent extends React.Component {
     this.props.postVote(commentId, hearingSlug, sectionId);
   }
 
-  handleDeleteClick = (sectionId, commentId) => {
-    this.setState({commentToDelete: {sectionId, commentId}});
+  handleDeleteClick = (sectionId, commentId, refreshUser) => {
+    this.setState({commentToDelete: {sectionId, commentId, refreshUser}});
     this.openDeleteModal();
   }
 
@@ -740,8 +740,8 @@ const mapDispatchToProps = (dispatch) => ({
   editComment: (hearingSlug, sectionId, commentId, commentData) => (
     dispatch(editSectionComment(hearingSlug, sectionId, commentId, commentData))
   ),
-  deleteSectionComment: (hearingSlug, sectionId, commentId) => (
-    dispatch(deleteSectionComment(hearingSlug, sectionId, commentId))
+  deleteSectionComment: (hearingSlug, sectionId, commentId, refreshUser) => (
+    dispatch(deleteSectionComment(hearingSlug, sectionId, commentId, refreshUser))
   ),
   fetchAllComments: (hearingSlug, sectionId, ordering) => (
     dispatch(fetchAllSectionComments(hearingSlug, sectionId, ordering))


### PR DESCRIPTION
Fixed issue where user was unable to add a new comment with answers immediately after deleting previously added comment that contained answers.

Changes:
- Added additional parameter `refreshUser` to the `deleteSectionComment` function that is true if the comment that is to be deleted contained answers. If true then the `user` is fetched from the server because the `user` object contains an `answered_questions` array that contains the id's of the questions that the user has previously answered.

[Link to trello card for this issue.](https://trello.com/c/PmOczAeG/32-k%C3%A4ytt%C3%A4j%C3%A4n-poistettu-kommentti-est%C3%A4%C3%A4-%C3%A4%C3%A4nest%C3%A4misen-uudelleen)