### PR TITLE
removed redundant dispatch that caused the profile page to crash

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -211,7 +211,6 @@ export function addHearingToFavorites(hearingSlug, hearingId) {
       if (data.status_code === 304) {
         localizedNotifyError("alreadyFavorite");
       } else {
-        dispatch(createAction("receiveFavoriteHearings")({hearingSlug, data}));
         dispatch(createAction("modifyFavoriteHearingsData")({hearingSlug, hearingId}));
         dispatch(fetchHearing(hearingSlug));
         localizedNotifySuccess("addedFavorites");


### PR DESCRIPTION
Removed unnecessary dispatch that caused the profile page to crash if the user didn't previously have any favorites and hadn't visited the profile page before adding a hearing to favorites.