### PR TITLE
Fixed label search links' initial focus placement

### DIFF
--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -18,7 +18,7 @@ exports[`HearingsList component should render as expected 1`] = `
           md={10}
           mdPush={1}
         >
-          <Connect(HearingsSearch)
+          <HearingsSearch
             intl={
               Object {
                 "defaultFormats": Object {},

--- a/src/components/HearingsSearch.js
+++ b/src/components/HearingsSearch.js
@@ -1,25 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 import {FormGroup, FormControl, ControlLabel, Button} from 'react-bootstrap';
 import {FormattedMessage, intlShape} from 'react-intl';
 import Select from 'react-select';
-import {get, isEmpty} from 'lodash';
+import {isEmpty} from 'lodash';
 import getAttr from '../utils/getAttr';
 import {labelShape} from '../types';
 
 class HearingsSearch extends React.Component {
-  constructor(props) {
-    super(props);
-    this.hearingFilterSearch = React.createRef();
-  }
-
-  componentDidUpdate() {
-    if (this.props.routerLocationState.filteredByLabelLink) {
-      this.hearingFilterSearch.current.focus();
-    }
-  }
-
   render() {
     const {
       handleSearch,
@@ -63,7 +51,6 @@ class HearingsSearch extends React.Component {
                   onChange={(value) => handleSelectLabels(value)}
                   placeholder={intl.formatMessage({id: 'searchPlaceholder'})}
                   id="formControlsSearchSelect"
-                  ref={this.hearingFilterSearch}
                 />
               )}
             </FormGroup>
@@ -80,10 +67,6 @@ class HearingsSearch extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  routerLocationState: get(state, 'router.location.state', {}),
-});
-
 HearingsSearch.propTypes = {
   handleSearch: PropTypes.func,
   handleSelectLabels: PropTypes.func,
@@ -92,7 +75,6 @@ HearingsSearch.propTypes = {
   searchPhrase: PropTypes.string,
   selectedLabels: PropTypes.arrayOf(PropTypes.string),
   intl: intlShape.isRequired,
-  routerLocationState: PropTypes.object,
 };
 
-export default connect(mapStateToProps)(HearingsSearch);
+export default HearingsSearch;


### PR DESCRIPTION
Removed manually set focus to label search input field when entering hearing search page with a label link. Now initial focus is naturally on top of the page instead of in the middle.