### PR TITLE
Fixed hearing search page’s skip links’ focus

### DIFF
--- a/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
+++ b/__tests__/Hearings/__snapshots__/HearingList.react-test.js.snap
@@ -457,15 +457,6 @@ exports[`HearingsList component should render as expected 1`] = `
     className="page-section page-section--hearings-list"
     id="hearings-section"
   >
-    <a
-      className="sr-only"
-      href="#hearings-search-form"
-    >
-      <FormattedMessage
-        id="jumpToSearchForm"
-        values={Object {}}
-      />
-    </a>
     <div
       className="container"
     >
@@ -479,6 +470,15 @@ exports[`HearingsList component should render as expected 1`] = `
           md={8}
           mdPush={2}
         >
+          <InternalLink
+            destinationId="hearings-search-form"
+            srOnly={true}
+          >
+            <FormattedMessage
+              id="jumpToSearchForm"
+              values={Object {}}
+            />
+          </InternalLink>
           <div>
             <div
               className="hearing-list__result-controls"

--- a/__tests__/InternalLink.react-test.js
+++ b/__tests__/InternalLink.react-test.js
@@ -18,7 +18,7 @@ describe('InternalLink', () => {
       const link = getWrapper().find(HashLink);
       expect(link).toHaveLength(1);
       const to = `${window.location.pathname}${window.location.search}#${defaultProps.destinationId}`;
-      expect(link.prop('className')).toBe(undefined);
+      expect(link.prop('className')).toBe('internal-link');
       expect(link.prop('to')).toBe(to);
       expect(link.prop('children')).toEqual(<span>test link</span>);
     });
@@ -26,7 +26,7 @@ describe('InternalLink', () => {
     test('HashLink with correct className when prop srOnly is true', () => {
       const link = getWrapper({srOnly: true}).find(HashLink);
       expect(link).toHaveLength(1);
-      expect(link.prop('className')).toBe('sr-only');
+      expect(link.prop('className')).toBe('internal-link hidden-link');
     });
   });
 });

--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -178,6 +178,22 @@ a.fullwidth {
   }
 }
 
+.hidden-link {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -999;
+
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+  }
+}
+
 .dropdown-toggle:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }

--- a/assets/sass/kerrokantasi/_hearing-list.scss
+++ b/assets/sass/kerrokantasi/_hearing-list.scss
@@ -203,6 +203,16 @@
     .Select-placeholder {
       color: $text-muted;
     }
+
+    #hearings-search-form {
+      scroll-margin-top: 100px;
+    }
+
+    .internal-link {
+      float: left;
+      margin-left: 8px;
+      margin-top: 6px;
+    }
   }
 
   &__label {
@@ -218,6 +228,10 @@
   &__button {
     float: left;
   }
+}
+
+#hearings-section {
+  scroll-margin-top: 100px;
 }
 
 .hearing-labels {

--- a/assets/sass/kerrokantasi/_hearing-page.scss
+++ b/assets/sass/kerrokantasi/_hearing-page.scss
@@ -26,22 +26,6 @@
       }
     }
   }
-
-  .hidden-link {
-    position: absolute;
-    left: -10000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    z-index: -999;
-
-    &:focus {
-      position: static;
-      width: auto;
-      height: auto;
-    }
-  }
 }
 
 .hearing-header {

--- a/src/components/HearingList.js
+++ b/src/components/HearingList.js
@@ -23,6 +23,7 @@ import { getHearingURL, isPublic } from '../utils/hearing';
 
 // eslint-disable-next-line import/no-unresolved
 import defaultImage from '@city-images/default-image.svg';
+import InternalLink from './InternalLink';
 
 const HEARING_LIST_TABS = {
   LIST: 'list',
@@ -282,12 +283,12 @@ export const HearingList = ({
         </div>
       </section>
       <section className="page-section page-section--hearings-list" id="hearings-section">
-        <a href="#hearings-search-form" className="sr-only">
-          <FormattedMessage id="jumpToSearchForm" />
-        </a>
         <div className="container">
           <Row>
             <Col md={8} mdPush={2}>
+              <InternalLink destinationId="hearings-search-form" srOnly>
+                <FormattedMessage id="jumpToSearchForm" />
+              </InternalLink>
               {(!isLoading && !hasHearings) && (
                 <h2 className="hearing-list__hearing-list-title">
                   <FormattedMessage id="noHearings">{txt => txt}</FormattedMessage>

--- a/src/components/HearingsSearch.js
+++ b/src/components/HearingsSearch.js
@@ -6,6 +6,7 @@ import Select from 'react-select';
 import {isEmpty} from 'lodash';
 import getAttr from '../utils/getAttr';
 import {labelShape} from '../types';
+import InternalLink from './InternalLink';
 
 class HearingsSearch extends React.Component {
   render() {
@@ -57,9 +58,9 @@ class HearingsSearch extends React.Component {
             <Button className="hearings-search__button" bsStyle="primary" type="submit">
               <FormattedMessage id="search"/>
             </Button>
-            <a href="#hearings-section" className="sr-only">
+            <InternalLink destinationId="hearings-section" srOnly>
               <FormattedMessage id="jumpToSearchResults" />
-            </a>
+            </InternalLink>
           </form>
         </div>
       </div>

--- a/src/components/InternalLink.js
+++ b/src/components/InternalLink.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 function InternalLink({children, destinationId, srOnly}) {
   const skipTo = `${window.location.pathname}${window.location.search}#${destinationId}`;
   return (
-    <HashLink className={srOnly ? 'sr-only' : undefined} to={skipTo}>
+    <HashLink className={srOnly ? 'internal-link hidden-link' : 'internal-link'} to={skipTo}>
       {children}
     </HashLink>
   );


### PR DESCRIPTION
Changes:
- fixed hearing search page's skip links’ focus not working as intended
- changed Internal link components screen reader only styles to show the link texts when the link is focused