### PR TITLE
Improved language switcher accessibility

### DIFF
--- a/__tests__/LanguageSwitcher-test.js
+++ b/__tests__/LanguageSwitcher-test.js
@@ -122,16 +122,26 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
 
     describe('Button', () => {
       test('has correct props', () => {
-        const element = getWrapper().find(Button);
+        const wrapper = getWrapper();
+        const instance = wrapper.instance();
+        const element = wrapper.find(Button);
+        expect(element.prop('aria-expanded')).toBe(instance.state.openDropdown);
+        expect(element.prop('aria-haspopup')).toBe(true);
         expect(element.prop('className')).toBe('language-switcher');
         expect(element.prop('onClick')).toBeDefined();
-        expect(element.prop('aria-label')).toBe(getMessage('languageSwitchLabel'));
         expect(element.prop('id')).toBe('language');
       });
 
-      describe('has correct child', () => {
+      describe('has correct children', () => {
+        const ariaHiddenSpan = getWrapper().find(Button).find('span').at(0);
+
+        test('aria-hidden span wrapper', () => {
+          expect(ariaHiddenSpan).toHaveLength(1);
+          expect(ariaHiddenSpan.prop('aria-hidden')).toBe("true");
+        });
+
         test('Icon', () => {
-          const element = getWrapper().find(Button).find(Icon);
+          const element = ariaHiddenSpan.find(Icon);
           expect(element).toHaveLength(1);
           expect(element.prop('name')).toBe('globe');
           expect(element.prop('className')).toBe('user-nav-icon');
@@ -139,8 +149,26 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
         });
 
         test('text for currentLanguage', () => {
-          const element = getWrapper().find(Button).find('span').at(0);
+          const element = ariaHiddenSpan.find('span').at(0);
           expect(element.text()).toContain(defaults.currentLanguage);
+        });
+
+        test('caret span', () => {
+          const element = ariaHiddenSpan.find('span').at(1);
+          expect(element.prop('className')).toBe('caret');
+        });
+
+        test('sr only language spans', () => {
+          const {languages} = config;
+          const languageSpans = getWrapper().find(Button).find('span').filter('.sr-only');
+          languageSpans.forEach((span, index) => {
+            const langCode = languages[index];
+            expect(span.prop('className')).toBe('sr-only');
+            expect(span.prop('lang')).toBe(langCode);
+            expect(span.text()).toBe(
+              `${getMessage('languageSwitchLabel', langCode)}${index + 1 < languages.length ? "," : ""}`
+            );
+          });
         });
       });
 
@@ -165,7 +193,6 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
       test('with correct props', () => {
         const element = getUL();
         expect(element.prop('className')).toBe('dropdown-menu dropdown-menu-right');
-        expect(element.prop('aria-labelledby')).toBe('language');
       });
 
       describe('li elements', () => {
@@ -190,7 +217,16 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
             const first = aElements;
             expect(first.prop('href')).toBe('#');
             expect(first.prop('aria-label')).toBe(getMessage(`lang-${languages[0]}`));
+            expect(first.prop('lang')).toBe(getMessage(languages[0]));
             expect(first.prop('onClick')).toBeDefined();
+          });
+
+          test('with correct aria-current prop', () => {
+            const aElements = getLinkAs({currentLanguage: languages[0]});
+            const first = aElements.at(0);
+            const second = aElements.at(1);
+            expect(first.prop('aria-current')).toBe(true);
+            expect(second.prop('aria-current')).toBe(false);
           });
 
           test('with correct texts', () => {

--- a/src/components/Header/LanguageSwitcher.js
+++ b/src/components/Header/LanguageSwitcher.js
@@ -81,6 +81,7 @@ class LanguageSwitcher extends React.Component {
   render() {
     const {currentLanguage, history, location} = this.props;
     const {openDropdown} = this.state;
+    const {languages} = config;
     return (
       <div
         className={classNames('dropdown', {open: openDropdown}, 'btn-group')}
@@ -99,16 +100,16 @@ class LanguageSwitcher extends React.Component {
             {currentLanguage}
             <span className="caret" />
           </span>
-          <span className="sr-only" lang="fi">Valitse kieli,</span>
-          <span className="sr-only" lang="sv">Ändra språk,</span>
-          <span className="sr-only" lang="en">Change language</span>
+          { languages.map((code, index) =>
+            <span className="sr-only" key={`${code}-key`} lang={code}>
+              {`${getMessage('languageSwitchLabel', code)}${index + 1 < languages.length ? "," : ""}`}
+            </span>
+          )}
         </Button>
         <ul className={classNames('dropdown-menu dropdown-menu-right')}>
-          { config.languages
-            .map((code) =>
-              this.getMenuItem(history, location, code)
-            )
-          }
+          { languages.map((code) =>
+            this.getMenuItem(history, location, code)
+          )}
         </ul>
       </div>
     );

--- a/src/components/Header/LanguageSwitcher.js
+++ b/src/components/Header/LanguageSwitcher.js
@@ -64,7 +64,9 @@ class LanguageSwitcher extends React.Component {
       <li key={code} className={classNames({active: code === currentLanguage})}>
         <a
           href="#"
+          aria-current={code === currentLanguage}
           aria-label={getMessage(`lang-${code}`)}
+          lang={code}
           onClick={(event) => {
             event.preventDefault();
             this.changeLanguage(history, location, code);
@@ -78,17 +80,30 @@ class LanguageSwitcher extends React.Component {
 
   render() {
     const {currentLanguage, history, location} = this.props;
+    const {openDropdown} = this.state;
     return (
-      // eslint-disable-next-line no-return-assign
-      <div className={classNames('dropdown', {open: this.state.openDropdown}, 'btn-group')} ref={node => this.node = node} >
-        <Button className="language-switcher" onClick={() => this.toggleDropdown()} aria-label={getMessage('languageSwitchLabel')} id="language">
-          <span>
+      <div
+        className={classNames('dropdown', {open: openDropdown}, 'btn-group')}
+        // eslint-disable-next-line no-return-assign
+        ref={node => this.node = node}
+      >
+        <Button
+          aria-expanded={openDropdown}
+          aria-haspopup
+          className="language-switcher"
+          id="language"
+          onClick={() => this.toggleDropdown()}
+        >
+          <span aria-hidden="true">
             <Icon name="globe" className="user-nav-icon" aria-hidden="true" />
             {currentLanguage}
             <span className="caret" />
           </span>
+          <span className="sr-only" lang="fi">Valitse kieli,</span>
+          <span className="sr-only" lang="sv">Ändra språk,</span>
+          <span className="sr-only" lang="en">Change language</span>
         </Button>
-        <ul className={classNames('dropdown-menu dropdown-menu-right')} aria-labelledby="language">
+        <ul className={classNames('dropdown-menu dropdown-menu-right')}>
           { config.languages
             .map((code) =>
               this.getMenuItem(history, location, code)


### PR DESCRIPTION
Changes:
- added `aria-expanded` and `aria-haspopup` attributes
- changed screen reader only label "choose language" to be in all supported languages instead of only in the currently selected language