### PR TITLE
Added localized del msgs in user profile page

### DIFF
--- a/__tests__/UserProfile/UserComment.react-test.js
+++ b/__tests__/UserProfile/UserComment.react-test.js
@@ -13,6 +13,9 @@ const defaultCommentData = {
   author: 'DefaultUser',
   created_at: new Date('10 September 2021 12:30').toISOString(),
   closed: false,
+  deleted: false,
+  deletedAt: null,
+  deletedByType: null,
   slug: 'hearingSlug',
   content: 'is this working?',
   geojson: null
@@ -24,6 +27,9 @@ const mockComment = (
   return {
     author_name: props.author || defaultCommentData.author,
     created_at: defaultCommentData.created_at,
+    deleted: props.deleted || defaultCommentData.deleted,
+    deleted_at: props.deletedAt || defaultCommentData.deletedAt,
+    deleted_by_type: props.deletedByType || defaultCommentData.deletedByType,
     hearing_data: {
       closed: props.closed || defaultCommentData.closed,
       slug: props.slug || defaultCommentData.slug,
@@ -113,6 +119,39 @@ describe('UserComment', () => {
         const element = wrapper.find('div.hearing-comment-body');
         expect(element).toHaveLength(1);
         expect(element.text()).toEqual(defaultCommentData.content);
+      });
+
+      describe('when comment is deleted', () => {
+        const deleted = true;
+        const deletedAt = '2022-01-31T09:45:00.284857Z';
+        const deletedByTypes = {moderator: 'moderator', self: 'self'};
+
+        test('by self', () => {
+          const comment = mockComment({deleted, deletedAt, deletedByType: deletedByTypes.self});
+          const wrapper = getWrapper({comment});
+          const element = wrapper.find('div.hearing-comment-body').find(FormattedMessage);
+          expect(element).toHaveLength(1);
+          expect(element.prop('id')).toBe('sectionCommentSelfDeletedMessage');
+        });
+
+        test('by moderator', () => {
+          const comment = mockComment({deleted, deletedAt, deletedByType: deletedByTypes.moderator});
+          const wrapper = getWrapper({comment});
+          const element = wrapper.find('div.hearing-comment-body').find(FormattedMessage);
+          expect(element).toHaveLength(1);
+          expect(element.prop('id')).toBe('sectionCommentDeletedMessage');
+          expect(element.prop('values')).toEqual({date:
+            moment(new Date(deletedAt)).format(' DD.MM.YYYY HH:mm')
+          });
+        });
+
+        test('by unknown type', () => {
+          const comment = mockComment({deleted, deletedAt});
+          const wrapper = getWrapper({comment});
+          const element = wrapper.find('div.hearing-comment-body').find(FormattedMessage);
+          expect(element).toHaveLength(1);
+          expect(element.prop('id')).toBe('sectionCommentGenericDeletedMessage');
+        });
       });
     });
     describe('comment contains geojson data', () => {

--- a/src/components/UserProfile/UserComment.js
+++ b/src/components/UserProfile/UserComment.js
@@ -41,6 +41,26 @@ class UserComment extends React.Component {
       </Tooltip>
     );
   }
+
+  renderCommentText = (comment) => {
+    if (!comment.deleted) {
+      return <p>{nl2br(comment.content)}</p>;
+    }
+    if (comment.deleted_by_type === "self") {
+      return <FormattedMessage id="sectionCommentSelfDeletedMessage"/>;
+    } else if (comment.deleted_by_type === "moderator") {
+      return (
+        <p>
+          <FormattedMessage
+            id="sectionCommentDeletedMessage"
+            values={{date: comment.deleted_at ? moment(new Date(comment.deleted_at)).format(' DD.MM.YYYY HH:mm') : ''}}
+          />
+        </p>
+      );
+    }
+    return <FormattedMessage id="sectionCommentGenericDeletedMessage"/>;
+  }
+
   /**
    * Toggles state.displayMap value
    */
@@ -84,7 +104,7 @@ class UserComment extends React.Component {
             </div>
           </div>
           <div className="hearing-comment-body">
-            <p>{nl2br(comment.content)}</p>
+            {this.renderCommentText(comment)}
           </div>
           <div className="hearing-comment__images">
             {comment.images


### PR DESCRIPTION
User's "comment deleted" messages are now shown in currently selected language in user profile page.