### PR TITLE
Cookiebot optionality and configuration

### DIFF
--- a/__tests__/Utils/cookieUtils.react-test.js
+++ b/__tests__/Utils/cookieUtils.react-test.js
@@ -1,24 +1,74 @@
 import React from 'react';
-import {
-  getCookieScripts
+import cookieUtils, {
+  getCookieScripts, getDefaultCookieScripts
 } from '../../src/utils/cookieUtils';
 import {shallow} from 'enzyme';
 // eslint-disable-next-line import/no-unresolved
 import urls from '@city-assets/urls.json';
+import cookiebotUtils from '../../src/utils/cookiebotUtils';
+
+const isCookiebotEnabledMock = jest.fn();
+jest.mock('../../src/utils/cookiebotUtils', () => {
+  const originalModule = jest.requireActual('../../src/utils/cookiebotUtils');
+  return {
+    __esModule: true,
+    ...originalModule,
+    isCookiebotEnabled: isCookiebotEnabledMock,
+    default: {
+      ...originalModule.default,
+      isCookiebotEnabled: () => isCookiebotEnabledMock(),
+    }
+  };
+});
+
+import config from '../../src/config';
 
 jest.mock('../../src/config', () => {
   return {
     enableCookies: true
   };
 });
+
 describe('cookieUtils', () => {
-  describe('getCookieScripts', () => {
+  describe('getDefaultCookieScripts', () => {
     test('returns a script element', () => {
-      const element = getCookieScripts();
+      const element = getDefaultCookieScripts();
       const wrapper = shallow(<div>{element}</div>);
       expect(wrapper.find('script')).toHaveLength(1);
       expect(wrapper.find('script').prop('src')).toEqual(urls.analytics);
       expect(wrapper.find('script').prop('type')).toEqual('text/javascript');
+    });
+  });
+
+  describe('getCookieScripts', () => {
+    describe('when isCookiebotEnabled returns true', () => {
+      isCookiebotEnabledMock.mockReturnValueOnce(true);
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      test('returns cookiebotUtils getCookieScripts', () => {
+        expect(getCookieScripts()).toEqual(cookiebotUtils.getCookieScripts());
+      });
+    });
+
+    describe('when isCookiebotEnabled returns false', () => {
+      isCookiebotEnabledMock.mockReturnValue(false);
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      test('when cookies are enabled, returns getDefaultCookieScripts', () => {
+        config.enableCookies = true;
+        expect(getCookieScripts()).toEqual(getDefaultCookieScripts());
+      });
+
+      test('when cookies are not enabled, returns null', () => {
+        config.enableCookies = false;
+        expect(cookieUtils.getCookieScripts()).toBe(null);
+      });
     });
   });
 });

--- a/__tests__/Utils/cookieUtils.react-test.js
+++ b/__tests__/Utils/cookieUtils.react-test.js
@@ -18,6 +18,7 @@ describe('cookieUtils', () => {
       const wrapper = shallow(<div>{element}</div>);
       expect(wrapper.find('script')).toHaveLength(1);
       expect(wrapper.find('script').prop('src')).toEqual(urls.analytics);
+      expect(wrapper.find('script').prop('type')).toEqual('text/javascript');
     });
   });
 });

--- a/__tests__/Utils/cookieUtils.react-test.js
+++ b/__tests__/Utils/cookieUtils.react-test.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import {
-  cookieBotAddListener,
-  cookieBotRemoveListener,
-  cookieBotImageOverride,
-  getConsentScripts,
   getCookieScripts
 } from '../../src/utils/cookieUtils';
-import config from '../../src/config';
 import {shallow} from 'enzyme';
 // eslint-disable-next-line import/no-unresolved
 import urls from '@city-assets/urls.json';
@@ -17,48 +12,6 @@ jest.mock('../../src/config', () => {
   };
 });
 describe('cookieUtils', () => {
-  describe('cookieBotAddListener', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-      config.enableCookies = true;
-    });
-    test('calls window.addEventListener with correct params if enableCookies is true', () => {
-      window.addEventListener = jest.fn();
-      cookieBotAddListener();
-      expect(window.addEventListener).toHaveBeenCalledWith('CookiebotOnDialogDisplay', cookieBotImageOverride);
-    });
-    test('does not call window.addEventListener when enableCookies is false', () => {
-      config.enableCookies = false;
-      window.addEventListener = jest.fn();
-      cookieBotAddListener();
-      expect(window.addEventListener).not.toHaveBeenCalled();
-    });
-  });
-  describe('cookieBotRemoveListener', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-      config.enableCookies = true;
-    });
-    test('calls window.removeEventListener with correct params if enableCookies is true', () => {
-      window.removeEventListener = jest.fn();
-      cookieBotRemoveListener();
-      expect(window.removeEventListener).toHaveBeenCalledWith('CookiebotOnDialogDisplay', cookieBotImageOverride);
-    });
-    test('does not call window.removeEventListener when enableCookies is false', () => {
-      config.enableCookies = false;
-      window.removeEventListener = jest.fn();
-      cookieBotRemoveListener();
-      expect(window.removeEventListener).not.toHaveBeenCalled();
-    });
-  });
-  describe('getConsentScripts', () => {
-    test('returns the Cookiebot script element', () => {
-      const element = getConsentScripts();
-      const wrapper = shallow(<div>{element}</div>);
-      expect(wrapper.find('script')).toHaveLength(1);
-      expect(wrapper.find('script').prop('id')).toBe('Cookiebot');
-    });
-  });
   describe('getCookieScripts', () => {
     test('returns a script element', () => {
       const element = getCookieScripts();

--- a/__tests__/Utils/cookiebotUtils.react-test.js
+++ b/__tests__/Utils/cookiebotUtils.react-test.js
@@ -17,7 +17,6 @@ jest.mock('../../src/config', () => {
   return {
     enableCookies: true,
     enableCookiebot: true,
-    cookiebotDataBlockingmode: 'auto',
     cookiebotDataCbid: '123-abc'
   };
 });
@@ -75,7 +74,7 @@ describe('cookiebotUtils', () => {
       const wrapper = shallow(<div>{element}</div>);
       expect(wrapper.find('script')).toHaveLength(1);
       expect(wrapper.find('script').prop('id')).toBe('Cookiebot');
-      expect(wrapper.find('script').prop('data-blockingmode')).toBe(config.cookiebotDataBlockingmode);
+      expect(wrapper.find('script').prop('data-blockingmode')).toBe('auto');
       expect(wrapper.find('script').prop('data-cbid')).toBe(config.cookiebotDataCbid);
       expect(wrapper.find('script').prop('src')).toBe('https://consent.cookiebot.com/uc.js');
       expect(wrapper.find('script').prop('type')).toBe('text/javascript');

--- a/__tests__/Utils/cookiebotUtils.react-test.js
+++ b/__tests__/Utils/cookiebotUtils.react-test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  cookieBotAddListener,
+  cookieBotRemoveListener,
+  cookieBotImageOverride,
+  getConsentScripts,
+} from '../../src/utils/cookiebotUtils';
+import config from '../../src/config';
+import {shallow} from 'enzyme';
+
+jest.mock('../../src/config', () => {
+  return {
+    enableCookies: true,
+    enableCookiebot: true,
+    cookiebotDataBlockingmode: 'auto',
+    cookiebotDataCbid: '123-abc'
+  };
+});
+describe('cookiebotUtils', () => {
+  describe('cookieBotAddListener', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      config.enableCookies = true;
+      config.enableCookiebot = true;
+    });
+    test('calls window.addEventListener with correct params if enableCookies and enableCookiebot is true', () => {
+      window.addEventListener = jest.fn();
+      cookieBotAddListener();
+      expect(window.addEventListener).toHaveBeenCalledWith('CookiebotOnDialogDisplay', cookieBotImageOverride);
+    });
+    test('does not call window.addEventListener when enableCookies is false', () => {
+      config.enableCookies = false;
+      window.addEventListener = jest.fn();
+      cookieBotAddListener();
+      expect(window.addEventListener).not.toHaveBeenCalled();
+    });
+    test('does not call window.addEventListener when enableCookiebot is false', () => {
+      config.enableCookiebot = false;
+      window.addEventListener = jest.fn();
+      cookieBotAddListener();
+      expect(window.addEventListener).not.toHaveBeenCalled();
+    });
+  });
+  describe('cookieBotRemoveListener', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      config.enableCookies = true;
+    });
+    test('calls window.removeEventListener with correct params if enableCookies and enableCookiebot is true', () => {
+      window.removeEventListener = jest.fn();
+      cookieBotRemoveListener();
+      expect(window.removeEventListener).toHaveBeenCalledWith('CookiebotOnDialogDisplay', cookieBotImageOverride);
+    });
+    test('does not call window.removeEventListener when enableCookies is false', () => {
+      config.enableCookies = false;
+      window.removeEventListener = jest.fn();
+      cookieBotRemoveListener();
+      expect(window.removeEventListener).not.toHaveBeenCalled();
+    });
+    test('does not call window.removeEventListener when enableCookiebot is false', () => {
+      config.enableCookiebot = false;
+      window.removeEventListener = jest.fn();
+      cookieBotRemoveListener();
+      expect(window.removeEventListener).not.toHaveBeenCalled();
+    });
+  });
+  describe('getConsentScripts', () => {
+    test('returns the Cookiebot script element', () => {
+      const element = getConsentScripts();
+      const wrapper = shallow(<div>{element}</div>);
+      expect(wrapper.find('script')).toHaveLength(1);
+      expect(wrapper.find('script').prop('id')).toBe('Cookiebot');
+      expect(wrapper.find('script').prop('data-blockingmode')).toBe(config.cookiebotDataBlockingmode);
+      expect(wrapper.find('script').prop('data-cbid')).toBe(config.cookiebotDataCbid);
+      expect(wrapper.find('script').prop('src')).toBe('https://consent.cookiebot.com/uc.js');
+      expect(wrapper.find('script').prop('type')).toBe('text/javascript');
+    });
+  });
+});

--- a/__tests__/Utils/cookiebotUtils.react-test.js
+++ b/__tests__/Utils/cookiebotUtils.react-test.js
@@ -5,6 +5,7 @@ import {
   cookieBotImageOverride,
   getConsentScripts,
   getCookieScripts,
+  isCookiebotEnabled,
 } from '../../src/utils/cookiebotUtils';
 import config from '../../src/config';
 import {shallow} from 'enzyme';
@@ -88,6 +89,30 @@ describe('cookiebotUtils', () => {
       expect(wrapper.find('script').prop('data-cookieconsent')).toEqual('statistics');
       expect(wrapper.find('script').prop('src')).toEqual(urls.analytics);
       expect(wrapper.find('script').prop('type')).toEqual('text/plain');
+    });
+  });
+
+  describe('isCookiebotEnabled', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('returns true when both cookies and Cookiebot are enabled', () => {
+      config.enableCookies = true;
+      config.enableCookiebot = true;
+      expect(isCookiebotEnabled()).toBe(true);
+    });
+
+    test('returns false when cookies are not enabled', () => {
+      config.enableCookies = false;
+      config.enableCookiebot = true;
+      expect(isCookiebotEnabled()).toBe(false);
+    });
+
+    test('returns false when Cookiebot is not enabled', () => {
+      config.enableCookies = true;
+      config.enableCookiebot = false;
+      expect(isCookiebotEnabled()).toBe(false);
     });
   });
 });

--- a/__tests__/Utils/cookiebotUtils.react-test.js
+++ b/__tests__/Utils/cookiebotUtils.react-test.js
@@ -4,9 +4,13 @@ import {
   cookieBotRemoveListener,
   cookieBotImageOverride,
   getConsentScripts,
+  getCookieScripts,
 } from '../../src/utils/cookiebotUtils';
 import config from '../../src/config';
 import {shallow} from 'enzyme';
+
+// eslint-disable-next-line import/no-unresolved
+import urls from '@city-assets/urls.json';
 
 jest.mock('../../src/config', () => {
   return {
@@ -74,6 +78,16 @@ describe('cookiebotUtils', () => {
       expect(wrapper.find('script').prop('data-cbid')).toBe(config.cookiebotDataCbid);
       expect(wrapper.find('script').prop('src')).toBe('https://consent.cookiebot.com/uc.js');
       expect(wrapper.find('script').prop('type')).toBe('text/javascript');
+    });
+  });
+  describe('getCookieScripts', () => {
+    test('returns a script element', () => {
+      const element = getCookieScripts();
+      const wrapper = shallow(<div>{element}</div>);
+      expect(wrapper.find('script')).toHaveLength(1);
+      expect(wrapper.find('script').prop('data-cookieconsent')).toEqual('statistics');
+      expect(wrapper.find('script').prop('src')).toEqual(urls.analytics);
+      expect(wrapper.find('script').prop('type')).toEqual('text/plain');
     });
   });
 });

--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -65,6 +65,12 @@ city_config="cities/helsinki"
 # Default: false
 # enable_cookies=true
 
+# Cookiebot consent management platform configuration. Cookiebot is disabled by default.
+# To use Cookiebot set both enable_cookies and enable_cookiebot to true.
+# enable_cookiebot=true
+# cookiebot_data_blockingmode="auto/none"
+# cookiebot_data_cbid="your-unique-cookiebot-domain-group-id"
+
 # Address for hearing admin help link
 # Default: "https://drive.google.com/open?id=1vtUNzbJNVcp7K9JPrE6XP8yTmkBLW3N3FGEsR1NbbIw"
 # admin_help_url=

--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -68,7 +68,6 @@ city_config="cities/helsinki"
 # Cookiebot consent management platform configuration. Cookiebot is disabled by default.
 # To use Cookiebot set both enable_cookies and enable_cookiebot to true.
 # enable_cookiebot=true
-# cookiebot_data_blockingmode="auto/none"
 # cookiebot_data_cbid="your-unique-cookiebot-domain-group-id"
 
 # Address for hearing admin help link

--- a/server/Html.js
+++ b/server/Html.js
@@ -29,6 +29,9 @@ export default class Html extends React.Component {
       showAccessibilityInfo,
       showSocialMediaSharing,
       enableCookies,
+      enableCookiebot,
+      cookiebotDataBlockingmode,
+      cookiebotDataCbid,
       uiConfig,
       openIdClientId,
       openIdAudience,
@@ -52,6 +55,9 @@ export default class Html extends React.Component {
     window.SHOW_SOCIAL_MEDIA_SHARING = ${JSON.stringify(showSocialMediaSharing)};
     window.ENABLE_HIGHCONTRAST = ${JSON.stringify(enableHighContrast)}
     window.ENABLE_COOKIES = ${JSON.stringify(enableCookies)};
+    window.ENABLE_COOKIEBOT = ${JSON.stringify(enableCookiebot)};
+    window.COOKIEBOT_DATA_BLOCKINGMODE = ${JSON.stringify(cookiebotDataBlockingmode)};
+    window.COOKIEBOT_DATA_CBID = ${JSON.stringify(cookiebotDataCbid)};
     window.ENABLE_STRONG_AUTH = ${JSON.stringify(enableStrongAuth)}
     window.ADMIN_HELP_URL = ${JSON.stringify(adminHelpUrl)};
     `;
@@ -93,6 +99,9 @@ Html.propTypes = {
   showAccessibilityInfo: PropTypes.bool,
   showSocialMediaSharing: PropTypes.bool,
   enableCookies: PropTypes.bool,
+  enableCookiebot: PropTypes.bool,
+  cookiebotDataBlockingmode: PropTypes.string,
+  cookiebotDataCbid: PropTypes.string,
   openIdClientId: PropTypes.string,
   openIdAudience: PropTypes.string,
   openIdAuthority: PropTypes.string,

--- a/server/Html.js
+++ b/server/Html.js
@@ -30,7 +30,6 @@ export default class Html extends React.Component {
       showSocialMediaSharing,
       enableCookies,
       enableCookiebot,
-      cookiebotDataBlockingmode,
       cookiebotDataCbid,
       uiConfig,
       openIdClientId,
@@ -56,7 +55,6 @@ export default class Html extends React.Component {
     window.ENABLE_HIGHCONTRAST = ${JSON.stringify(enableHighContrast)}
     window.ENABLE_COOKIES = ${JSON.stringify(enableCookies)};
     window.ENABLE_COOKIEBOT = ${JSON.stringify(enableCookiebot)};
-    window.COOKIEBOT_DATA_BLOCKINGMODE = ${JSON.stringify(cookiebotDataBlockingmode)};
     window.COOKIEBOT_DATA_CBID = ${JSON.stringify(cookiebotDataCbid)};
     window.ENABLE_STRONG_AUTH = ${JSON.stringify(enableStrongAuth)}
     window.ADMIN_HELP_URL = ${JSON.stringify(adminHelpUrl)};
@@ -100,7 +98,6 @@ Html.propTypes = {
   showSocialMediaSharing: PropTypes.bool,
   enableCookies: PropTypes.bool,
   enableCookiebot: PropTypes.bool,
-  cookiebotDataBlockingmode: PropTypes.string,
   cookiebotDataCbid: PropTypes.string,
   openIdClientId: PropTypes.string,
   openIdAudience: PropTypes.string,

--- a/server/render-middleware.js
+++ b/server/render-middleware.js
@@ -41,6 +41,9 @@ function renderHTMLSkeleton(req, res, settings) {
         showAccessibilityInfo={settings.show_accessibility_info}
         showSocialMediaSharing={settings.show_social_media_sharing}
         enableCookies={settings.enable_cookies}
+        enableCookiebot={settings.enable_cookiebot}
+        cookiebotDataBlockingmode={settings.cookiebot_data_blockingmode}
+        cookiebotDataCbid={settings.cookiebot_data_cbid}
         openIdClientId={settings.openid_client_id}
         openIdAudience={settings.openid_audience}
         openIdAuthority={settings.openid_authority}

--- a/server/render-middleware.js
+++ b/server/render-middleware.js
@@ -42,7 +42,6 @@ function renderHTMLSkeleton(req, res, settings) {
         showSocialMediaSharing={settings.show_social_media_sharing}
         enableCookies={settings.enable_cookies}
         enableCookiebot={settings.enable_cookiebot}
-        cookiebotDataBlockingmode={settings.cookiebot_data_blockingmode}
         cookiebotDataCbid={settings.cookiebot_data_cbid}
         openIdClientId={settings.openid_client_id}
         openIdAudience={settings.openid_audience}

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import {checkHeadlessParam} from './utils/urlQuery';
 import classNames from 'classnames';
 import cookieUtil from './utils/cookieUtils';
 import { HashLink } from 'react-router-hash-link';
+import cookiebotUtils from './utils/cookiebotUtils';
 
 class App extends React.Component {
   getChildContext() {
@@ -31,11 +32,11 @@ class App extends React.Component {
 
   componentDidMount() {
     config.activeLanguage = this.props.language; // for non react-intl localizations
-    cookieUtil.cookieBotAddListener();
+    cookiebotUtils.cookieBotAddListener();
   }
 
   componentWillUnmount() {
-    cookieUtil.cookieBotRemoveListener();
+    cookiebotUtils.cookieBotRemoveListener();
   }
 
   render() {
@@ -78,7 +79,7 @@ class App extends React.Component {
             meta={favmeta}
           >
             <html lang={locale} />
-            {config.enableCookies && cookieUtil.getConsentScripts()}
+            {(config.enableCookies && config.enableCookiebot) && cookiebotUtils.getConsentScripts()}
             {config.enableCookies && cookieUtil.getCookieScripts()}
           </Helmet>
           {header}

--- a/src/App.js
+++ b/src/App.js
@@ -67,16 +67,6 @@ class App extends React.Component {
     }
     const mainContainerId = "main-container";
     const skipTo = `${this.props.location.pathname}${this.props.location.search}#${mainContainerId}`;
-    const useCookiebot = config.enableCookies && config.enableCookiebot;
-    const getCookieScripts = () => {
-      if (useCookiebot) {
-        return cookiebotUtils.getCookieScripts();
-      } else if (config.enableCookies) {
-        return cookieUtil.getCookieScripts();
-      }
-      return null;
-    };
-
     return (
       <IntlProvider locale={locale} messages={messages[locale] || {}}>
         <div className={contrastClass}>
@@ -89,8 +79,8 @@ class App extends React.Component {
             meta={favmeta}
           >
             <html lang={locale} />
-            {useCookiebot && cookiebotUtils.getConsentScripts()}
-            {getCookieScripts()}
+            {cookiebotUtils.isCookiebotEnabled() && cookiebotUtils.getConsentScripts()}
+            {cookieUtil.getCookieScripts()}
           </Helmet>
           {header}
           <main

--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,16 @@ class App extends React.Component {
     }
     const mainContainerId = "main-container";
     const skipTo = `${this.props.location.pathname}${this.props.location.search}#${mainContainerId}`;
+    const useCookiebot = config.enableCookies && config.enableCookiebot;
+    const getCookieScripts = () => {
+      if (useCookiebot) {
+        return cookiebotUtils.getCookieScripts();
+      } else if (config.enableCookies) {
+        return cookieUtil.getCookieScripts();
+      }
+      return null;
+    };
+
     return (
       <IntlProvider locale={locale} messages={messages[locale] || {}}>
         <div className={contrastClass}>
@@ -79,8 +89,8 @@ class App extends React.Component {
             meta={favmeta}
           >
             <html lang={locale} />
-            {(config.enableCookies && config.enableCookiebot) && cookiebotUtils.getConsentScripts()}
-            {config.enableCookies && cookieUtil.getCookieScripts()}
+            {useCookiebot && cookiebotUtils.getConsentScripts()}
+            {getCookieScripts()}
           </Helmet>
           {header}
           <main

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,6 @@ const config = {
   enableHighContrast: typeof window !== 'undefined' ? window.ENABLE_HIGHCONTRAST : false,
   enableCookies: typeof window !== 'undefined' ? window.ENABLE_COOKIES : false,
   enableCookiebot: typeof window !== 'undefined' ? window.ENABLE_COOKIEBOT : false,
-  cookiebotDataBlockingmode: typeof window !== 'undefined' ? window.COOKIEBOT_DATA_BLOCKINGMODE : null,
   cookiebotDataCbid: typeof window !== 'undefined' ? window.COOKIEBOT_DATA_CBID : null,
   enableStrongAuth: typeof window !== 'undefined' ? window.ENABLE_STRONG_AUTH : false,
   adminHelpUrl: typeof window !== 'undefined' ? window.ADMIN_HELP_URL : "",

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,9 @@ const config = {
   showSocialMediaSharing: typeof window !== 'undefined' ? window.SHOW_SOCIAL_MEDIA_SHARING : true,
   enableHighContrast: typeof window !== 'undefined' ? window.ENABLE_HIGHCONTRAST : false,
   enableCookies: typeof window !== 'undefined' ? window.ENABLE_COOKIES : false,
+  enableCookiebot: typeof window !== 'undefined' ? window.ENABLE_COOKIEBOT : false,
+  cookiebotDataBlockingmode: typeof window !== 'undefined' ? window.COOKIEBOT_DATA_BLOCKINGMODE : null,
+  cookiebotDataCbid: typeof window !== 'undefined' ? window.COOKIEBOT_DATA_CBID : null,
   enableStrongAuth: typeof window !== 'undefined' ? window.ENABLE_STRONG_AUTH : false,
   adminHelpUrl: typeof window !== 'undefined' ? window.ADMIN_HELP_URL : "",
 };

--- a/src/utils/cookieUtils.js
+++ b/src/utils/cookieUtils.js
@@ -1,50 +1,7 @@
 /* eslint-disable react/self-closing-comp */
-import config from '../config';
 import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import urls from '@city-assets/urls.json';
-/**
- * Add event listener that overrides the image served by cookiebot.
- */
-export function cookieBotAddListener() {
-  if (config.enableCookies) {
-    window.addEventListener('CookiebotOnDialogDisplay', cookieBotImageOverride);
-  }
-}
-
-/**
- * Remove event listener that overrides the image served by cookiebot.
- */
-export function cookieBotRemoveListener() {
-  if (config.enableCookies) {
-    window.removeEventListener('CookiebotOnDialogDisplay', cookieBotImageOverride);
-  }
-}
-
-/**
- * Sets the cookiebot banner's header <img> src to empty string,
- * so the image specified by the style rules is shown instead.
- */
-export function cookieBotImageOverride() {
-  document.getElementById('CybotCookiebotDialogPoweredbyImage').src = '';
-}
-
-/**
- * Returns the Cookiebot <script> element
- * @returns {JSX.Element}
- */
-export function getConsentScripts() {
-  return (
-    <script
-      data-blockingmode="auto"
-      data-cbid="92860cd1-d931-4496-8621-2adb011dafb0"
-      id="Cookiebot"
-      src="https://consent.cookiebot.com/uc.js"
-      type="text/javascript"
-    >
-    </script>
-  );
-}
 
 /**
  * Returns a <script> element with src urls.analytics
@@ -62,9 +19,5 @@ export function getCookieScripts() {
 }
 
 export default {
-  cookieBotAddListener,
-  cookieBotRemoveListener,
-  cookieBotImageOverride,
-  getConsentScripts,
   getCookieScripts
 };

--- a/src/utils/cookieUtils.js
+++ b/src/utils/cookieUtils.js
@@ -2,12 +2,14 @@
 import React from 'react';
 // eslint-disable-next-line import/no-unresolved
 import urls from '@city-assets/urls.json';
+import cookiebotUtils from './cookiebotUtils';
+import config from '../config';
 
 /**
- * Returns a <script> element with src urls.analytics
- * @returns {JSX.Element}
+ * Returns a default cookie script element with src urls.analytics
+ * @returns {JSX.Element} script element
  */
-export function getCookieScripts() {
+export function getDefaultCookieScripts() {
   return (
     <script
       type="text/javascript"
@@ -17,6 +19,21 @@ export function getCookieScripts() {
   );
 }
 
+/**
+ * Returns a script element based on config settings with src urls.analytics
+ * or null when cookies are not enabled.
+ * @returns {JSX.Element|null} script element or null
+ */
+export function getCookieScripts() {
+  if (cookiebotUtils.isCookiebotEnabled()) {
+    return cookiebotUtils.getCookieScripts();
+  } else if (config.enableCookies) {
+    return getDefaultCookieScripts();
+  }
+  return null;
+}
+
 export default {
-  getCookieScripts
+  getDefaultCookieScripts,
+  getCookieScripts,
 };

--- a/src/utils/cookieUtils.js
+++ b/src/utils/cookieUtils.js
@@ -10,9 +10,8 @@ import urls from '@city-assets/urls.json';
 export function getCookieScripts() {
   return (
     <script
-      type="text/plain"
+      type="text/javascript"
       src={urls.analytics}
-      data-cookieconsent="statistics"
     >
     </script>
   );

--- a/src/utils/cookiebotUtils.js
+++ b/src/utils/cookiebotUtils.js
@@ -1,0 +1,53 @@
+/* eslint-disable react/self-closing-comp */
+import config from '../config';
+import React from 'react';
+
+/**
+ * Add event listener that overrides the image served by cookiebot.
+ */
+export function cookieBotAddListener() {
+  if (config.enableCookies && config.enableCookiebot) {
+    window.addEventListener('CookiebotOnDialogDisplay', cookieBotImageOverride);
+  }
+}
+
+/**
+ * Remove event listener that overrides the image served by cookiebot.
+ */
+export function cookieBotRemoveListener() {
+  if (config.enableCookies && config.enableCookiebot) {
+    window.removeEventListener('CookiebotOnDialogDisplay', cookieBotImageOverride);
+  }
+}
+
+/**
+ * Sets the cookiebot banner's header <img> src to empty string,
+ * so the image specified by the style rules is shown instead.
+ */
+export function cookieBotImageOverride() {
+  document.getElementById('CybotCookiebotDialogPoweredbyImage').src = '';
+}
+
+/**
+ * Returns the Cookiebot <script> element
+ * @returns {JSX.Element}
+ */
+export function getConsentScripts() {
+  return (
+    <script
+      data-blockingmode={config.cookiebotDataBlockingmode}
+      data-cbid={config.cookiebotDataCbid}
+      id="Cookiebot"
+      src="https://consent.cookiebot.com/uc.js"
+      type="text/javascript"
+    >
+    </script>
+  );
+}
+
+export default {
+  cookieBotAddListener,
+  cookieBotRemoveListener,
+  cookieBotImageOverride,
+  getConsentScripts,
+};

--- a/src/utils/cookiebotUtils.js
+++ b/src/utils/cookiebotUtils.js
@@ -23,7 +23,7 @@ export function cookieBotRemoveListener() {
 }
 
 /**
- * Sets the cookiebot banner's header <img> src to empty string,
+ * Sets the cookiebot banner's header img src to empty string,
  * so the image specified by the style rules is shown instead.
  */
 export function cookieBotImageOverride() {
@@ -31,8 +31,8 @@ export function cookieBotImageOverride() {
 }
 
 /**
- * Returns the Cookiebot <script> element
- * @returns {JSX.Element}
+ * Returns the Cookiebot script element
+ * @returns {JSX.Element} script element
  */
 export function getConsentScripts() {
   return (
@@ -48,8 +48,8 @@ export function getConsentScripts() {
 }
 
 /**
- * Returns a <script> element with src urls.analytics
- * @returns {JSX.Element}
+ * Returns a script element with src urls.analytics
+ * @returns {JSX.Element} script element
  */
 export function getCookieScripts() {
   return (
@@ -62,10 +62,19 @@ export function getCookieScripts() {
   );
 }
 
+/**
+ * Returns whether Cookiebot is enabled and should be used or not.
+ * @returns {boolean} true when Cookiebot is enabled, else false if not.
+ */
+export function isCookiebotEnabled() {
+  return config.enableCookies && config.enableCookiebot;
+}
+
 export default {
   cookieBotAddListener,
   cookieBotRemoveListener,
   cookieBotImageOverride,
   getConsentScripts,
   getCookieScripts,
+  isCookiebotEnabled,
 };

--- a/src/utils/cookiebotUtils.js
+++ b/src/utils/cookiebotUtils.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/self-closing-comp */
 import config from '../config';
 import React from 'react';
+// eslint-disable-next-line import/no-unresolved
+import urls from '@city-assets/urls.json';
 
 /**
  * Add event listener that overrides the image served by cookiebot.
@@ -45,9 +47,25 @@ export function getConsentScripts() {
   );
 }
 
+/**
+ * Returns a <script> element with src urls.analytics
+ * @returns {JSX.Element}
+ */
+export function getCookieScripts() {
+  return (
+    <script
+      data-cookieconsent="statistics"
+      src={urls.analytics}
+      type="text/plain"
+    >
+    </script>
+  );
+}
+
 export default {
   cookieBotAddListener,
   cookieBotRemoveListener,
   cookieBotImageOverride,
   getConsentScripts,
+  getCookieScripts,
 };

--- a/src/utils/cookiebotUtils.js
+++ b/src/utils/cookiebotUtils.js
@@ -37,7 +37,7 @@ export function cookieBotImageOverride() {
 export function getConsentScripts() {
   return (
     <script
-      data-blockingmode={config.cookiebotDataBlockingmode}
+      data-blockingmode="auto"
       data-cbid={config.cookiebotDataCbid}
       id="Cookiebot"
       src="https://consent.cookiebot.com/uc.js"


### PR DESCRIPTION
Cookiebot's use is no longer controlled with only `enable_cookies` config setting and cookies can be used without Cookiebot. To use Cookiebot:
- both `enable_cookies` and `enable_cookiebot` must be true
- fill out Cookiebot specific settings