### PR TITLE
Updated redux dev tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "react-waypoint": "^9.0.3",
     "redux": "^3.7.2",
     "redux-actions": "^2.6.5",
-    "redux-logger": "^2.0.4",
     "redux-oidc": "^3.1.7",
     "redux-raven-middleware": "^1.2.0",
     "redux-thunk": "^2.3.0",

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -40,17 +40,12 @@ if (config.uiConfig && config.uiConfig.sentryDns) {
   ));
 }
 
-if (typeof window !== 'undefined') {
-  if (!(process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test')) {
-    middleware.push(require('redux-logger')());
-  }
-}
-
 export default function createAppStore(initialState = null) {
   // Have to pass in the router to support isomorphic rendering
   const augmentedCreateStore = compose(
     applyMiddleware(...middleware),
-    typeof window !== 'undefined' && window.devToolsExtension ? window.devToolsExtension() : identity,
+    typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__
+      ? window.__REDUX_DEVTOOLS_EXTENSION__() : identity,
   )(createStore);
   return augmentedCreateStore(rootReducer, initialState || {});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3739,11 +3739,6 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
-deep-diff@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
-  integrity sha1-qsXDmVIjar5fA3ojSQYLoBsArkg=
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -10241,13 +10236,6 @@ redux-actions@^2.6.5:
     loose-envify "^1.4.0"
     reduce-reducers "^0.4.3"
     to-camel-case "^1.0.0"
-
-redux-logger@^2.0.4:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.10.2.tgz#3c5a5f0a6f32577c1deadf6655f257f82c6c3937"
-  integrity sha1-PFpfCm8yV3wd6t9mVfJX+CxsOTc=
-  dependencies:
-    deep-diff "0.3.4"
 
 redux-oidc@^3.1.7:
   version "3.1.7"


### PR DESCRIPTION
# Updated Redux dev tools

## Update fixes Redux dev tools for the browser plugin and removes old Redux console logger

### [Related Trello card](https://trello.com/c/hSyoFD1C) and [new Redux dev tools usage](https://github.com/zalmoxisus/redux-devtools-extension#usage)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Redux dev tools update
 1. src/createStore.js
     * Removed old redux logger and renamed redux dev tools
    
 2. package.json
     * Removed old redux logger package

 3. yarn.lock
     * Removed old redux logger package