### PR TITLE
Changed language switcher accessible name

### DIFF
--- a/__tests__/LanguageSwitcher-test.js
+++ b/__tests__/LanguageSwitcher-test.js
@@ -133,15 +133,14 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
       });
 
       describe('has correct children', () => {
-        const ariaHiddenSpan = getWrapper().find(Button).find('span').at(0);
+        const wrapperSpan = getWrapper().find(Button).find('span').at(0);
 
-        test('aria-hidden span wrapper', () => {
-          expect(ariaHiddenSpan).toHaveLength(1);
-          expect(ariaHiddenSpan.prop('aria-hidden')).toBe("true");
+        test('span wrapper', () => {
+          expect(wrapperSpan).toHaveLength(1);
         });
 
         test('Icon', () => {
-          const element = ariaHiddenSpan.find(Icon);
+          const element = wrapperSpan.find(Icon);
           expect(element).toHaveLength(1);
           expect(element.prop('name')).toBe('globe');
           expect(element.prop('className')).toBe('user-nav-icon');
@@ -149,13 +148,14 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
         });
 
         test('text for currentLanguage', () => {
-          const element = ariaHiddenSpan.find('span').at(0);
+          const element = wrapperSpan.find('span').at(0);
           expect(element.text()).toContain(defaults.currentLanguage);
         });
 
         test('caret span', () => {
-          const element = ariaHiddenSpan.find('span').at(1);
+          const element = wrapperSpan.find('span').at(1);
           expect(element.prop('className')).toBe('caret');
+          expect(element.prop('aria-hidden')).toBe('true');
         });
 
         test('sr only language spans', () => {
@@ -166,7 +166,7 @@ describe('src/components/Header/LanguageSwitcherV2', () => {
             expect(span.prop('className')).toBe('sr-only');
             expect(span.prop('lang')).toBe(langCode);
             expect(span.text()).toBe(
-              `${getMessage('languageSwitchLabel', langCode)}${index + 1 < languages.length ? "," : ""}`
+              `, ${getMessage('languageSwitchLabel', langCode)}`
             );
           });
         });

--- a/src/components/Header/LanguageSwitcher.js
+++ b/src/components/Header/LanguageSwitcher.js
@@ -95,14 +95,14 @@ class LanguageSwitcher extends React.Component {
           id="language"
           onClick={() => this.toggleDropdown()}
         >
-          <span aria-hidden="true">
+          <span>
             <Icon name="globe" className="user-nav-icon" aria-hidden="true" />
             {currentLanguage}
-            <span className="caret" />
+            <span className="caret" aria-hidden="true"/>
           </span>
-          { languages.map((code, index) =>
+          { languages.map((code) =>
             <span className="sr-only" key={`${code}-key`} lang={code}>
-              {`${getMessage('languageSwitchLabel', code)}${index + 1 < languages.length ? "," : ""}`}
+              {`, ${getMessage('languageSwitchLabel', code)}`}
             </span>
           )}
         </Button>


### PR DESCRIPTION
# Changed language switcher accessible name

## Language switcher accessible name now includes the visible label's language code e.g. FI

### [Related Trello card](https://trello.com/c/yhEARh81)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Language switcher accessible name
 1. src/components/Header/LanguageSwitcher.js
     * Changed accessible name to include language code