### PR TITLE
Added link controls to abstract editor field

### DIFF
--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -33,6 +33,7 @@ import IframeEntity from './Iframe/IframeEntity';
 import SkipLinkModal from './SkipLink/SkipLinkModal';
 import ImageModal from './Image/ImageModal';
 import ImageEntity from './Image/ImageEntity';
+import { textEditorHideControlsShape } from '../../types';
 
 const getBlockStyle = (block) => {
   switch (block.getType()) {
@@ -585,7 +586,7 @@ class RichTextEditor extends React.Component {
       hideImageControls,
       hideSkipLinkControls,
       hideLinkControls
-    } = this.props;
+    } = this.props.hideControls;
     return (
       <div className="rich-text-editor">
         <ControlLabel>
@@ -664,21 +665,18 @@ class RichTextEditor extends React.Component {
 }
 
 RichTextEditor.defaultProps = {
-  hideBlockStyleControls: false,
-  hideInlineStyleControls: false,
-  hideIframeControls: false,
-  hideImageControls: false,
-  hideSkipLinkControls: false,
-  hideLinkControls: false,
+  hideControls: {
+    hideBlockStyleControls: false,
+    hideInlineStyleControls: false,
+    hideIframeControls: false,
+    hideImageControls: false,
+    hideSkipLinkControls: false,
+    hideLinkControls: false,
+  }
 };
 
 RichTextEditor.propTypes = {
-  hideBlockStyleControls: PropTypes.bool,
-  hideInlineStyleControls: PropTypes.bool,
-  hideIframeControls: PropTypes.bool,
-  hideImageControls: PropTypes.bool,
-  hideSkipLinkControls: PropTypes.bool,
-  hideLinkControls: PropTypes.bool,
+  hideControls: textEditorHideControlsShape,
   labelId: PropTypes.string,
   onBlur: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -578,44 +578,70 @@ class RichTextEditor extends React.Component {
 
   render() {
     const { editorState } = this.state;
+    const {
+      hideBlockStyleControls,
+      hideInlineStyleControls,
+      hideIframeControls,
+      hideImageControls,
+      hideSkipLinkControls,
+      hideLinkControls
+    } = this.props;
     return (
       <div className="rich-text-editor">
         <ControlLabel>
           <FormattedMessage id={this.props.labelId}/>
         </ControlLabel>
-        <BlockStyleControls
-          editorState={editorState}
-          onToggle={this.toggleBlockType}
-        />
-        <InlineStyleControls
-          editorState={editorState}
-          onToggle={this.toggleInlineStyle}
-        />
-        <IframeControls
-          onClick={this.openIframeModal}
-        />
-        <IframeModal
-          isOpen={this.state.showIframeModal}
-          onClose={this.closeIframeModal}
-          onSubmit={this.confirmIframe}
-        />
-        <ImageControls
-          onClick={this.openImageModal}
-        />
-        <ImageModal
-          isOpen={this.state.showImageModal}
-          onClose={this.closeImageModal}
-          onSubmit={this.confirmImage}
-        />
-        <SkipLinkControls
-          onClick={this.openSkipLinkModal}
-        />
-        <SkipLinkModal
-          isOpen={this.state.showSkipLinkModal}
-          onClose={this.closeSkipLinkModal}
-          onSubmit={this.confirmSkipLink}
-        />
-        {this.renderHyperlinkButton()}
+        {!hideBlockStyleControls && (
+          <BlockStyleControls
+            editorState={editorState}
+            onToggle={this.toggleBlockType}
+          />
+        )}
+        {!hideInlineStyleControls && (
+          <InlineStyleControls
+            editorState={editorState}
+            onToggle={this.toggleInlineStyle}
+          />
+        )}
+        {!hideIframeControls && (
+          <React.Fragment>
+            <IframeControls
+                  onClick={this.openIframeModal}
+            />
+            <IframeModal
+              isOpen={this.state.showIframeModal}
+              onClose={this.closeIframeModal}
+              onSubmit={this.confirmIframe}
+            />
+          </React.Fragment>
+        )}
+        {!hideImageControls && (
+          <React.Fragment>
+            <ImageControls
+              onClick={this.openImageModal}
+            />
+            <ImageModal
+              isOpen={this.state.showImageModal}
+              onClose={this.closeImageModal}
+              onSubmit={this.confirmImage}
+            />
+          </React.Fragment>
+        )}
+        {!hideSkipLinkControls && (
+        <React.Fragment>
+          <SkipLinkControls
+            onClick={this.openSkipLinkModal}
+          />
+          <SkipLinkModal
+            isOpen={this.state.showSkipLinkModal}
+            onClose={this.closeSkipLinkModal}
+            onSubmit={this.confirmSkipLink}
+          />
+        </React.Fragment>
+        )}
+        {!hideLinkControls && (
+          this.renderHyperlinkButton()
+        )}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <div onClick={this.onFocus}>
           <Editor
@@ -637,7 +663,22 @@ class RichTextEditor extends React.Component {
   }
 }
 
+RichTextEditor.defaultProps = {
+  hideBlockStyleControls: false,
+  hideInlineStyleControls: false,
+  hideIframeControls: false,
+  hideImageControls: false,
+  hideSkipLinkControls: false,
+  hideLinkControls: false,
+};
+
 RichTextEditor.propTypes = {
+  hideBlockStyleControls: PropTypes.bool,
+  hideInlineStyleControls: PropTypes.bool,
+  hideIframeControls: PropTypes.bool,
+  hideImageControls: PropTypes.bool,
+  hideSkipLinkControls: PropTypes.bool,
+  hideLinkControls: PropTypes.bool,
   labelId: PropTypes.string,
   onBlur: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/components/admin/SectionForm.js
+++ b/src/components/admin/SectionForm.js
@@ -280,6 +280,12 @@ class SectionForm extends React.Component {
           languages={sectionLanguages}
           fieldType={TextFieldTypes.TEXTAREA}
           placeholderId="sectionAbstractPlaceholder"
+          richTextEditor
+          hideBlockStyleControls
+          hideInlineStyleControls
+          hideIframeControls
+          hideImageControls
+          hideSkipLinkControls
         />
 
         <MultiLanguageTextField

--- a/src/components/admin/SectionForm.js
+++ b/src/components/admin/SectionForm.js
@@ -281,11 +281,13 @@ class SectionForm extends React.Component {
           fieldType={TextFieldTypes.TEXTAREA}
           placeholderId="sectionAbstractPlaceholder"
           richTextEditor
-          hideBlockStyleControls
-          hideInlineStyleControls
-          hideIframeControls
-          hideImageControls
-          hideSkipLinkControls
+          hideControls={{
+            hideBlockStyleControls: true,
+            hideInlineStyleControls: true,
+            hideIframeControls: true,
+            hideImageControls: true,
+            hideSkipLinkControls: true
+          }}
         />
 
         <MultiLanguageTextField

--- a/src/components/forms/MultiLanguageTextField.js
+++ b/src/components/forms/MultiLanguageTextField.js
@@ -4,6 +4,7 @@ import {injectIntl, FormattedMessage} from 'react-intl';
 import TextInput from './TextInput';
 import TextArea from './TextArea';
 import RichTextEditor from '../RichTextEditor';
+import { textEditorHideControlsShape } from '../../types';
 
 export const TextFieldTypes = {
   INPUT: 'input',
@@ -47,12 +48,7 @@ class MultiLanguageTextField extends React.Component {
   render() {
     const {
       fieldType,
-      hideBlockStyleControls,
-      hideInlineStyleControls,
-      hideIframeControls,
-      hideImageControls,
-      hideSkipLinkControls,
-      hideLinkControls,
+      hideControls,
       languages,
       value,
       labelId,
@@ -78,12 +74,7 @@ class MultiLanguageTextField extends React.Component {
           if (richTextEditor) {
             return (
               <RichTextEditor
-                hideBlockStyleControls={hideBlockStyleControls}
-                hideInlineStyleControls={hideInlineStyleControls}
-                hideIframeControls={hideIframeControls}
-                hideImageControls={hideImageControls}
-                hideSkipLinkControls={hideSkipLinkControls}
-                hideLinkControls={hideLinkControls}
+                hideControls={hideControls}
                 key={lang}
                 labelId={`inLanguage-${lang}`}
                 value={currentValue}
@@ -115,6 +106,7 @@ class MultiLanguageTextField extends React.Component {
 MultiLanguageTextField.propTypes = {
   defaultValue: PropTypes.object, // TODO: create shape! {'fi': ..., 'sv': ..., 'en': ...}
   fieldType: PropTypes.string,
+  hideControls: textEditorHideControlsShape,
   hideBlockStyleControls: PropTypes.bool,
   hideInlineStyleControls: PropTypes.bool,
   hideIframeControls: PropTypes.bool,
@@ -135,12 +127,14 @@ MultiLanguageTextField.propTypes = {
 
 MultiLanguageTextField.defaultProps = {
   fieldType: TextFieldTypes.INPUT,
-  hideBlockStyleControls: false,
-  hideInlineStyleControls: false,
-  hideIframeControls: false,
-  hideImageControls: false,
-  hideSkipLinkControls: false,
-  hideLinkControls: false,
+  hideControls: {
+    hideBlockStyleControls: false,
+    hideInlineStyleControls: false,
+    hideIframeControls: false,
+    hideImageControls: false,
+    hideSkipLinkControls: false,
+    hideLinkControls: false,
+  }
 };
 
 export default injectIntl(MultiLanguageTextField);

--- a/src/components/forms/MultiLanguageTextField.js
+++ b/src/components/forms/MultiLanguageTextField.js
@@ -107,12 +107,6 @@ MultiLanguageTextField.propTypes = {
   defaultValue: PropTypes.object, // TODO: create shape! {'fi': ..., 'sv': ..., 'en': ...}
   fieldType: PropTypes.string,
   hideControls: textEditorHideControlsShape,
-  hideBlockStyleControls: PropTypes.bool,
-  hideInlineStyleControls: PropTypes.bool,
-  hideIframeControls: PropTypes.bool,
-  hideImageControls: PropTypes.bool,
-  hideSkipLinkControls: PropTypes.bool,
-  hideLinkControls: PropTypes.bool,
   labelId: PropTypes.string,
   languages: PropTypes.arrayOf(PropTypes.string),
   onBlur: PropTypes.func,

--- a/src/components/forms/MultiLanguageTextField.js
+++ b/src/components/forms/MultiLanguageTextField.js
@@ -47,6 +47,12 @@ class MultiLanguageTextField extends React.Component {
   render() {
     const {
       fieldType,
+      hideBlockStyleControls,
+      hideInlineStyleControls,
+      hideIframeControls,
+      hideImageControls,
+      hideSkipLinkControls,
+      hideLinkControls,
       languages,
       value,
       labelId,
@@ -72,6 +78,12 @@ class MultiLanguageTextField extends React.Component {
           if (richTextEditor) {
             return (
               <RichTextEditor
+                hideBlockStyleControls={hideBlockStyleControls}
+                hideInlineStyleControls={hideInlineStyleControls}
+                hideIframeControls={hideIframeControls}
+                hideImageControls={hideImageControls}
+                hideSkipLinkControls={hideSkipLinkControls}
+                hideLinkControls={hideLinkControls}
                 key={lang}
                 labelId={`inLanguage-${lang}`}
                 value={currentValue}
@@ -103,6 +115,12 @@ class MultiLanguageTextField extends React.Component {
 MultiLanguageTextField.propTypes = {
   defaultValue: PropTypes.object, // TODO: create shape! {'fi': ..., 'sv': ..., 'en': ...}
   fieldType: PropTypes.string,
+  hideBlockStyleControls: PropTypes.bool,
+  hideInlineStyleControls: PropTypes.bool,
+  hideIframeControls: PropTypes.bool,
+  hideImageControls: PropTypes.bool,
+  hideSkipLinkControls: PropTypes.bool,
+  hideLinkControls: PropTypes.bool,
   labelId: PropTypes.string,
   languages: PropTypes.arrayOf(PropTypes.string),
   onBlur: PropTypes.func,
@@ -116,7 +134,13 @@ MultiLanguageTextField.propTypes = {
 };
 
 MultiLanguageTextField.defaultProps = {
-  fieldType: TextFieldTypes.INPUT
+  fieldType: TextFieldTypes.INPUT,
+  hideBlockStyleControls: false,
+  hideInlineStyleControls: false,
+  hideIframeControls: false,
+  hideImageControls: false,
+  hideSkipLinkControls: false,
+  hideLinkControls: false,
 };
 
 export default injectIntl(MultiLanguageTextField);

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,14 @@ export const contactShape = PropTypes.shape({
   title: translatedShape,
 });
 
+export const textEditorHideControlsShape = PropTypes.shape({
+  hideBlockStyleControls: PropTypes.bool,
+  hideInlineStyleControls: PropTypes.bool,
+  hideIframeControls: PropTypes.bool,
+  hideImageControls: PropTypes.bool,
+  hideSkipLinkControls: PropTypes.bool,
+  hideLinkControls: PropTypes.bool,
+});
 
 export const sectionImageShape = PropTypes.shape({
   id: PropTypes.number,


### PR DESCRIPTION
# Added link controls to editor's abstract field

## Links can be added for abstract in hearing editor and rich text editor controls can be toggled individually per rich text editor field

### [Related Trello card](https://trello.com/c/qsMUCnkr)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Link controls for abstract fields
 1. src/components/RichTextEditor/index.js
     * changed controls to be togglable via props
   
 2. src/components/admin/SectionForm.js
     * changed abstract field to be a rich text field and with only link controls
    
 3. src/components/forms/MultiLanguageTextField.js
     * props passing