### PR TITLE
Removed incorrect html attrs from hearing page

### DIFF
--- a/__tests__/Hearing/__snapshots__/SectionContainer.react-test.js.snap
+++ b/__tests__/Hearing/__snapshots__/SectionContainer.react-test.js.snap
@@ -51,7 +51,6 @@ exports[`SectionContainer component should render as expected 1`] = `
               id="hearing-section-details-accordion"
               in={true}
               mountOnEnter={false}
-              role="region"
               timeout={300}
               unmountOnExit={false}
             >

--- a/src/components/Hearing/Section/SectionContainer.js
+++ b/src/components/Hearing/Section/SectionContainer.js
@@ -259,7 +259,6 @@ export class SectionContainerComponent extends React.Component {
           in={this.state.mainHearingAttachmentsOpen}
           id="hearing-section-attachments-accordion"
           aria-hidden={this.state.mainHearingAttachmentsOpen ? "false" : "true"}
-          role="region"
         >
           <div className="accordion-content">
             <div className="section-content-spacer">
@@ -311,7 +310,6 @@ export class SectionContainerComponent extends React.Component {
           in={this.state.mainHearingProjectOpen}
           id="hearing-section-project-accordion"
           aria-hidden={this.state.mainHearingProjectOpen ? "false" : "true"}
-          role="region"
         >
           <div className="accordion-content">
             <div className="project-phases-list section-content-spacer">
@@ -381,7 +379,6 @@ export class SectionContainerComponent extends React.Component {
           in={this.state.mainHearingContactsOpen}
           id="hearing-section-contacts-accordion"
           aria-hidden={this.state.mainHearingContactsOpen ? "false" : "true"}
-          role="region"
         >
           <div className="accordion-content">
             <div className="section-content-spacer">
@@ -541,7 +538,6 @@ export class SectionContainerComponent extends React.Component {
             in={this.state.mainHearingDetailsOpen}
             id="hearing-section-details-accordion"
             aria-hidden={this.state.mainHearingDetailsOpen ? "false" : "true"}
-            role="region"
           >
             <div className="accordion-content">
               <div className="section-content-spacer">


### PR DESCRIPTION
# Removal of incorrect html attributes in hearing page

## Removed attribute `role` `region` from all `Collapse` elements in hearing page. Removing the role attribute also removes incorrect attribute `aria-expanded` from `Collapse` elements

### [Related Trello card](https://trello.com/c/P6SrMVKm)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Removal of incorrect html attribute
 1. src/components/Hearing/Section/SectionContainer.js
     * Removed incorrect role region attr from collapse elements which also removes auto added incorrect aria-expanded attr