### PR TITLE
changes to when a hearings questions can be edited

### DIFF
--- a/__tests__/hearingUtils.js
+++ b/__tests__/hearingUtils.js
@@ -5,8 +5,11 @@ import {
   getOrCreateSectionByID,
   getSectionByID,
   initNewHearing,
+  isEditableQuestion,
+  isPublic,
 } from '../src/utils/hearing';
-
+import {initNewSection} from '../src/utils/section';
+import moment from 'moment';
 
 test('New hearing initializer accepts initial values', () => {
   const hearing = initNewHearing({slug: "test-slug"});
@@ -57,4 +60,111 @@ test('Anonymous user is not allowed to edit hearing', () => {
   const hearing = initNewHearing({organization: "test-org"});
   const user = null;
   expect(canEdit(user, hearing)).toBe(false);
+});
+
+describe('isPublic', () => {
+  test('returns true if hearing is visible to the public', () => {
+    // hearing opened yesterday
+    const hearing = initNewHearing({open_at: moment().subtract(1, 'days'), published: true});
+    expect(isPublic(hearing)).toBe(true);
+  });
+
+  test('returns false if hearing is not visible to the public', () => {
+    // hearing will open tomorrow
+    const hearing = initNewHearing({open_at: moment().add(1, 'days'), published: true});
+    expect(isPublic(hearing)).toBe(false);
+  });
+});
+
+describe('isEditableQuestion', () => {
+  const sectionOne = initNewSection({questions: [{n_answers: 0}]});
+  const sectionTwo = initNewSection({questions: [{n_answers: 0}, {n_answers: 0}]});
+  const sectionOneAnswered = initNewSection({questions: [{n_answers: 1}]});
+  const sectionTwoAnswered = initNewSection({questions: [{n_answers: 0}, {n_answers: 2}]});
+
+
+  const today = (exp = 'add', days = 0) => {
+    if (exp === 'add') { return moment().add(days, 'days'); }
+    return moment().subtract(days, 'days');
+  };
+
+  test('returns true when hearing is a draft that is waiting for publishing date', () => {
+    const hearing = initNewHearing({
+      open_at: today('add', 1),
+      close_at: today('add', 2),
+      published: true,
+      closed: true,
+      sections: [sectionOne, sectionTwo],
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(true);
+  });
+
+  test('returns true when hearing is a draft that has not been approved for publishing', () => {
+    const hearing = initNewHearing({
+      open_at: today('add', 1),
+      close_at: today('add', 2),
+      published: false,
+      closed: true,
+      sections: [sectionOne, sectionTwo],
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(true);
+  });
+
+  test('returns true when hearing has been published and is open but has no comments', () => {
+    const hearing = initNewHearing({
+      open_at: today('sub', 1),
+      close_at: today('add', 2),
+      published: true,
+      closed: false,
+      sections: [sectionOne, sectionTwo],
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(true);
+  });
+
+  test('returns false when hearing has been published and is open but has comments', () => {
+    const hearing = initNewHearing({
+      open_at: today('sub', 1),
+      close_at: today('add', 2),
+      published: true,
+      closed: false,
+      sections: [sectionOne, sectionTwoAnswered],
+      n_comments: 2,
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(false);
+  });
+
+  test('returns true when hearing was open and published but was unpublished with no comments', () => {
+    const hearing = initNewHearing({
+      open_at: today('sub', 1),
+      close_at: today('add', 2),
+      published: false,
+      closed: false,
+      sections: [sectionOne, sectionTwo],
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(true);
+  });
+
+  test('returns false when hearing was open and published but was unpublished with added comments', () => {
+    const hearing = initNewHearing({
+      open_at: today('sub', 1),
+      close_at: today('add', 2),
+      published: false,
+      closed: false,
+      sections: [sectionOneAnswered, sectionTwo],
+      n_comments: 1,
+      id: 'id'
+    }
+    );
+    expect(isEditableQuestion(hearing)).toBe(false);
+  });
 });

--- a/src/components/admin/HearingFormStep2.js
+++ b/src/components/admin/HearingFormStep2.js
@@ -12,7 +12,7 @@ import Icon from '../../utils/Icon';
 
 import SectionForm from './SectionForm';
 import {addSection, removeSection} from '../../actions/hearingEditor';
-import {getMainSection, isPublic} from '../../utils/hearing';
+import {getMainSection, isPublic, isEditableQuestion} from '../../utils/hearing';
 import {hearingShape} from '../../types';
 import {initNewSection, SectionTypes} from '../../utils/section';
 import getAttr from '../../utils/getAttr';
@@ -86,6 +86,7 @@ class HearingFormStep2 extends React.Component {
                   isFirstSubsection={index === 1}
                   isLastSubsection={sectionID === last(hearing.sections).frontId}
                   isPublic={isPublic(hearing)}
+                  isEditableQuestion={isEditableQuestion(hearing)}
                   onDeleteTemporaryQuestion={onDeleteTemporaryQuestion}
                   onEditSectionAttachmentOrder={this.props.onEditSectionAttachmentOrder}
                   onQuestionChange={onQuestionChange}

--- a/src/components/admin/QuestionForm.js
+++ b/src/components/admin/QuestionForm.js
@@ -115,26 +115,34 @@ export class QuestionForm extends React.Component {
   }
 
   render() {
-    const {question, isPublic} = this.props;
+    const {question: {frontId, id, n_answers: nAnswers}, isPublic, isEditableQuestion} = this.props;
+    const editableQuestion = frontId || (id && !isPublic && nAnswers === 0) || isEditableQuestion;
     /**
-     * Display editable form when question is new or when the hearing is not yet public/hasn't been public.
-     * Otherwise display details of existing questions
+     * Display editable form when:
+     * - the question is new
+     * - the hearing is a draft
+     * - hearing has been published but is waiting for publishing date.
+     * - hearing is public but doesn't have any comments
+     * - hearing was previously public but was unpublished and doesn't have any comments.
+     *
+     * In all other cases display details of existing questions.
      */
-    return (question.frontId || (question.id && !isPublic && question.n_answers === 0))
+    return editableQuestion
       ? this.getEditableForm() : this.getQuestionDetails();
   }
 }
 
 QuestionForm.propTypes = {
-  question: PropTypes.object,
-  sectionId: PropTypes.string,
   addOption: PropTypes.func,
   deleteOption: PropTypes.func,
-  sectionLanguages: PropTypes.array,
-  onQuestionChange: PropTypes.func,
+  isEditableQuestion: PropTypes.bool,
+  isPublic: PropTypes.bool,
   lang: PropTypes.string,
   onDeleteExistingQuestion: PropTypes.func,
-  isPublic: PropTypes.bool,
+  onQuestionChange: PropTypes.func,
+  question: PropTypes.object,
+  sectionId: PropTypes.string,
+  sectionLanguages: PropTypes.array,
 };
 
 export default QuestionForm;

--- a/src/components/admin/SectionForm.js
+++ b/src/components/admin/SectionForm.js
@@ -240,6 +240,7 @@ class SectionForm extends React.Component {
     const {
       addOption,
       deleteOption,
+      isEditableQuestion,
       isFirstSubsection,
       isLastSubsection,
       isPublic,
@@ -477,6 +478,7 @@ class SectionForm extends React.Component {
               onDeleteExistingQuestion={onDeleteExistingQuestion}
               lang={language}
               isPublic={isPublic}
+              isEditableQuestion={isEditableQuestion}
             />
           </div>
         )}
@@ -495,6 +497,7 @@ SectionForm.propTypes = {
   initMultipleChoiceQuestion: PropTypes.func,
   initSingleChoiceQuestion: PropTypes.func,
   intl: intlShape.isRequired,
+  isEditableQuestion: PropTypes.bool,
   isFirstSubsection: PropTypes.bool,
   isLastSubsection: PropTypes.bool,
   isPublic: PropTypes.bool,


### PR DESCRIPTION
# Changes to when a hearings questions can be edited

#### A hearings questions can now be edited even after publishing as long as no comments have been added. For specific cases when a question can be edited see comments added to QuestionForm.js. Added tests for the new isEditableQuestion function and did some minor refactoring.
[Trello card for this feature](https://trello.com/c/byfv8wgo/140-yksi-ja-monivalintakysymysten-muokkaaminen)
-----------------------------------------------------------------------------------------------
Changes:
- **src/utils/hearing.js**
Added new function isEditableQuestion that is used to determine if a hearings questions should be editable, See QuestionForm.js for details about when a hearings questions should be editable.

- **tests__/hearingUtils.js**
Added tests for isEditableQuestion and isPublic.

- **src/components/admin/HearingFormStep2.js**
Added import for isEditableQuestion which is pass onward to SectionForm.

- **src/components/admin/SectionForm.js**
Added new prop isEditableQuestion which is passed onward to QuestionForm.

- **src/components/admin/QuestionForm.js**
Added new isEditableQuestion prop which is used to determine if a hearings question should be editable, minor refactoring/rearranging of proptypes.