### PR TITLE
Added missing doctype html

### DIFF
--- a/server/render-middleware.js
+++ b/server/render-middleware.js
@@ -53,7 +53,7 @@ function renderHTMLSkeleton(req, res, settings) {
         enableResponseCompression={settings.enable_response_compression}
       />
     );
-    res.status(200).send(html);
+    res.status(200).send('<!DOCTYPE html>' + html);
   });
 }
 


### PR DESCRIPTION
# Page doctype

## Added required missing doctype html

### [Related Trello card](https://trello.com/c/OEHJcFvO)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### html
 1. server/render-middleware.js
     * Added missing doctype html in front of all other html