### PR TITLE
Fixed some maps from not being drawn correctly

### DIFF
--- a/__tests__/UserProfile/UserComment.react-test.js
+++ b/__tests__/UserProfile/UserComment.react-test.js
@@ -199,6 +199,7 @@ describe('UserComment', () => {
           expect(mapElement.prop('hearing')).toEqual(geojsonValues);
           expect(mapElement.prop('mapContainer')).toEqual(wrapper.state('mapContainer'));
           expect(mapElement.prop('mapSettings')).toEqual({dragging: false});
+          expect(mapElement.prop('style')).toEqual({height: "250px", width: "100%"});
         });
       });
     });

--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -605,9 +605,10 @@ class Comment extends React.Component {
                 >
                   {data.geojson && (
                   <HearingMap
-                  hearing={{geojson: data.geojson}}
-                  mapContainer={this.state.mapContainer}
-                  mapSettings={{dragging: false}}
+                    hearing={{geojson: data.geojson}}
+                    mapContainer={this.state.mapContainer}
+                    mapSettings={{dragging: false}}
+                    style={{height: '250px', width: '100%'}}
                   />
                   )}
                 </div>

--- a/src/components/UserProfile/UserComment.js
+++ b/src/components/UserProfile/UserComment.js
@@ -147,6 +147,7 @@ class UserComment extends React.Component {
                       hearing={{geojson: comment.geojson}}
                       mapContainer={this.state.mapContainer}
                       mapSettings={{dragging: false}}
+                      style={{height: '250px', width: '100%'}}
                     />
                   )}
                 </div>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -66,7 +66,7 @@ export class Home extends React.Component {
           <OverviewMap
             enablePopups
             hearings={openHearings.data}
-            style={{width: '100%', height: isMobile ? '70%' : 600}}
+            style={{width: '100%', height: isMobile ? '70vh' : 600}}
             mapElementLimit={10}
           />
         </div>


### PR DESCRIPTION
# Fix to some maps not being drawn correctly

## Fixed maps with % based height values from not being drawn correctly by either adding a fixed px or vh based height

### [Related Trello card](https://trello.com/c/51jK4A3a)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Map height changes
 1. src/components/Hearing/Comment/index.js
     * Added fixed px height value to map
   
 2. src/components/UserProfile/UserComment.js
     * Added fixed px height value to map
    
 3. src/views/Home.js
     * changed map height unit from % to vh for narrow devices