### PR TITLE
Fixed home page lead hearing title text overflow

### DIFF
--- a/assets/sass/kerrokantasi/_fullwidth-hearing.scss
+++ b/assets/sass/kerrokantasi/_fullwidth-hearing.scss
@@ -26,7 +26,8 @@
   }
 
   &-title-wrap {
-    padding-right: 70px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 
     .fullwidth-hearing-comments {
       position: absolute;


### PR DESCRIPTION
#  Home page lead hearing title text overflow

## Fixed lead hearing text overflow which most likely occurs with narrow width devices like mobile phones

### [Related Trello card](https://trello.com/c/X8mwdU8c)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Home page lead hearing title text overflow
 1. assets/sass/kerrokantasi/_fullwidth-hearing.scss
     * Added work break
     * Removed padding right
