### PR TITLE
Fixed overview map popup showing html

### DIFF
--- a/assets/sass/kerrokantasi/_common.scss
+++ b/assets/sass/kerrokantasi/_common.scss
@@ -9,6 +9,7 @@ h1:focus,
 #main-container:not(.fullscreen) {
   min-height: 80vh;
   min-height: calc(100vh - 125px - 400px);
+
   &.headless {
     min-height: calc(100vh - 400px);
   }
@@ -108,8 +109,10 @@ a[target=_blank]::after {
 }
 
 a.list-group-item {
-  &:hover, &:focus {
-    > .badge {
+
+  &:hover,
+  &:focus {
+    >.badge {
       background: #fff;
       color: $theme-highlight-dark;
     }
@@ -210,6 +213,11 @@ a.fullwidth {
 .Select--multi .Select-value {
   color: $brand-info !important;
 }
+
 .Select-clear-zone {
   color: $text-muted !important;
+}
+
+.overview-map-popup-content {
+  word-wrap: break-word;
 }

--- a/src/components/OverviewMap.js
+++ b/src/components/OverviewMap.js
@@ -210,11 +210,14 @@ class OverviewMap extends React.Component {
       const hearingURL = getHearingURL(hearing) + document.location.search;
       return (
         <Popup {...options}>
-          <div>
+          <div className="overview-map-popup-content">
             <h4>
               <a href={hearingURL}>{getAttr(hearing.title, language)}</a>
             </h4>
-            <p>{getAttr(hearing.abstract, language)}</p>
+            <div
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: getAttr(hearing.abstract, language) }}
+            />
           </div>
         </Popup>
       );


### PR DESCRIPTION
# Overview map popup text html and text overflow

## Fixed overview map popup abstract being shown as html and fixed overview map popup text potential text overflow

### [Related Trello card](https://trello.com/c/kLTeg8Xj)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Text overflow fix
 1. assets/sass/kerrokantasi/_common.scss
     * added word break
     
#### Overview map popup abstract
 1. src/components/OverviewMap.js
     * abstract is now rendered directly as html
