### PR TITLE
Deletable question options

### DIFF
--- a/src/actions/hearingEditor.js
+++ b/src/actions/hearingEditor.js
@@ -37,7 +37,7 @@ export const EditorActions = {
   CLOSE_FORM: 'closeHearingForm',
   CLOSE_HEARING: 'closeHearing',
   CREATE_MAP_MARKER: 'createMapMarker',
-  DELETE_LAST_OPTION: 'deleteLastOption',
+  DELETE_OPTION: 'deleteOption',
   DELETE_TEMP_QUESTION: 'deleteTemporaryQuestion',
   EDIT_HEARING: 'changeHearing',
   EDIT_PHASE: 'changePhase',
@@ -397,9 +397,17 @@ export const deleteTemporaryQuestion = (sectionId, questionFrontId) => {
   return createAction(EditorActions.DELETE_TEMP_QUESTION)({sectionId, questionFrontId});
 };
 
-export const deleteLastOption = (sectionId, questionId, optionKey) => {
+/**
+ * Delete given option from question form.
+ * @param {string} sectionId id of the section that contains the question.
+ * @param {number|string} questionId id of the question that contains the option.
+ * @param {number} optionKey id or index of the options that is to be deleted.
+ * @param {boolean} [useOptionIndex=false] determines if optionKey should be handled as index when deleting option.
+ * @returns {function(*): *}
+ */
+export const deleteOption = (sectionId, questionId, optionKey, useOptionIndex) => {
   return dispatch => {
-    return dispatch(createAction(EditorActions.DELETE_LAST_OPTION)({sectionId, questionId, optionKey}));
+    return dispatch(createAction(EditorActions.DELETE_OPTION)({sectionId, questionId, optionKey, useOptionIndex}));
   };
 };
 

--- a/src/components/admin/HearingEditor.js
+++ b/src/components/admin/HearingEditor.js
@@ -17,7 +17,7 @@ import {
   closeHearing,
   closeHearingForm,
   createMapMarker,
-  deleteLastOption,
+  deleteOption,
   deleteSectionAttachment,
   deleteTemporaryQuestion,
   editQuestion,
@@ -186,9 +186,9 @@ class HearingEditor extends React.Component {
       }
     }
 
+    this.setState({errors: localErrors});
     // true if one of the keys in localErrors contain entries
     // eslint-disable-next-line no-unused-vars
-    this.setState({errors: localErrors});
     const containsError = Object.entries(localErrors).some(([k, v]) => Object.entries(v).length > 0);
     if (!containsError) {
       return dispatch(callbackAction(hearing));
@@ -255,9 +255,9 @@ class HearingEditor extends React.Component {
     dispatch(addOption(sectionId, questionId));
   }
 
-  deleteOption = (sectionId, questionId) => {
+  deleteOption = (sectionId, questionId, optionKey, useIndex) => {
     const {dispatch} = this.props;
-    dispatch(deleteLastOption(sectionId, questionId));
+    dispatch(deleteOption(sectionId, questionId, optionKey, useIndex));
   }
 
   getHearingForm() {

--- a/src/components/admin/QuestionForm.js
+++ b/src/components/admin/QuestionForm.js
@@ -54,10 +54,17 @@ export class QuestionForm extends React.Component {
             </div>
             <div style={{flex: '1', marginTop: '48px', marginLeft: '15px'}}>
               {
-                question.options.length > 2 && index === question.options.length - 1 &&
+                question.options.length > 2 &&
                 <Button
                   bsStyle="danger"
-                  onClick={() => deleteOption(sectionId, question.frontId || question.id, index)}
+                  onClick={() =>
+                    deleteOption(sectionId, (question.frontId || question.id), (option.id || index), !option.id)
+                    // The 2nd params question.frontId exists only when creating a new question that hasn't been saved,
+                    // if it's falsy -> use the actual .id value.
+                    // Third param works in a similar manner, option.id exists for options that have been saved,
+                    // when deleting options that haven't been saved -> use the index number.
+                    // Fourth param is true IF option.id is falsy -> true when deleting options that haven't been saved.
+                }
                 >
                   <Icon style={{fontSize: '24px'}} className="icon" name="trash" />
                 </Button>

--- a/src/reducers/hearingEditor/sections.js
+++ b/src/reducers/hearingEditor/sections.js
@@ -151,17 +151,22 @@ const byId = handleActions(
         }
       }, state);
     },
-    [EditorActions.DELETE_LAST_OPTION]: (state, {payload: {sectionId, questionId}}) => {
-      const index = findIndex(
+    [EditorActions.DELETE_OPTION]: (state, {payload: {sectionId, questionId, optionKey, useOptionIndex = false}}) => {
+      const questionIndex = findIndex(
         state[sectionId].questions,
         (quest) => quest.frontId === questionId || quest.id === questionId
       );
-      const question = state[sectionId].questions[index];
-      const newOptions = question.options.slice(0, -1);
+      const question = state[sectionId].questions[questionIndex];
+      let newOptions;
+      if (useOptionIndex) {
+        newOptions = question.options.filter((val, index) => index !== optionKey);
+      } else {
+        newOptions = question.options.filter(option => option.id !== optionKey);
+      }
       return updeep({
         [sectionId]: {
           questions: {
-            [index]: {
+            [questionIndex]: {
               options: newOptions
             }
           }


### PR DESCRIPTION
# Deletable question options


#### A questions options are now deletable as long as they are editable. Previously it was only possible to delete the last option, but with these changes one can delete any options as long as the question itself editable (editable as long as the hearing hasn't received any comments or hasn't closed).
[Trello card for this feature.](https://trello.com/c/Ewku0yO1/158-monivalintakyselyn-vaihtoehdon-poistaminen)
-----------------------------------------------------------------------------------------------
Changes:
- **tests__/reducers/sections.react-test.js**
Added tests for the `DELETE_OPTION` dispatch, refactored old tests.

- **src/actions/hearingEditor.js**
Added new `DELETE_OPTION` to `EditorActions`.
Added new `deleteOption` function that dispatches the new DELETE_OPTION action.

- **src/components/admin/HearingEditor.js**
Changed the `deleteOption` method to use the new deleteOption dispatch.
Fixed lint errors.

- **src/components/admin/QuestionForm.js**
Options are now deletable as long as **there are more than 2 options** and the question itself is editable (hearing hasn't received comments or hasn't closed)

- **src/reducers/hearingEditor/sections.js**
Replaced the old `DELETE_LAST_OPTION` section with the new `DELETE_OPTION`.
