### PR TITLE
Added missing comment edit save btn translations

### DIFF
--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -385,7 +385,7 @@ class Comment extends React.Component {
             }}
           />
         </FormGroup>
-        <Button type="submit">Save</Button>
+        <Button type="submit"><FormattedMessage id="save"/></Button>
       </form>
     </React.Fragment>
   );


### PR DESCRIPTION
# Missing comment edit save button translations

## Comment edit save button text was hardcoded and this fix adds translations to the button

### [Related Trello card](https://trello.com/c/9qTY7LK3)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Missing translations
 1. src/components/Hearing/Comment/index.js
     * replaced hardcoded "save" with translated save texts
