### PR TITLE
Fixed comment question answer editing

### DIFF
--- a/src/components/Hearing/Comment/index.js
+++ b/src/components/Hearing/Comment/index.js
@@ -352,6 +352,7 @@ class Comment extends React.Component {
         key={`$answer-for-question-${answer.question}`}
         loggedIn={!isEmpty(this.props.user)}
         onChange={this.handleAnswerChange}
+        canAnswer={this.props.canReply}
       />
     );
   };


### PR DESCRIPTION
# Fix to comment question answer editing

## Users could not edit their questions answers due to missing permission parameter

### [Related Trello card](https://trello.com/c/uDHY0CMR)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix to comment question answer editing
 1. src/components/Hearing/Comment/index.js
     * Added missing `canAnswer` prop
   
