### PR TITLE
Fixed a potential crash caused by comment loading

### DIFF
--- a/src/components/Hearing/CommentList/index.js
+++ b/src/components/Hearing/CommentList/index.js
@@ -16,8 +16,8 @@ export class CommentList extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const {comments: newComments} = this.props;
-    if (prevProps.comments !== newComments) {
+    const {comments: newComments, section} = this.props;
+    if (prevProps.section.id === section.id && prevProps.comments !== newComments) {
       const updatedLoadingState = newComments.reduce((acc, curr, index) => {
         /**
          * loadingSubComments is undefined by default, boolean true is added once we start fetching


### PR DESCRIPTION
# Fix to a potential crash caused by sub comment loading

## Sub comment loading did not work correctly when moving between hearing sub sections. This fix changes sub section comment loading to be handled only when the section is the same.

### [Related Trello card](https://trello.com/c/13yO5xzj)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Sub section sub comment loading error fix
 1. src/components/Hearing/CommentList/index.js
     * sub comment loading is handled only when section is same as before