### PR TITLE
Changed autofocus targeting for comment form

### DIFF
--- a/__tests__/Hearing/QuestionForm.react-test.js
+++ b/__tests__/Hearing/QuestionForm.react-test.js
@@ -7,6 +7,7 @@ import { Checkbox, FormGroup, HelpBlock, Radio } from 'react-bootstrap';
 
 describe('QuestionForm', () => {
   const defaultProps = {
+    autoFocus: false,
     question: {
       id: 10,
       is_independent_poll: false,
@@ -109,6 +110,7 @@ describe('QuestionForm', () => {
         const radios = getWrapper({canAnswer, question}).find(Radio);
         expect(radios).toHaveLength(3);
         radios.forEach((radio, index) => {
+          expect(radio.prop('autoFocus')).toBe(false);
           expect(radio.prop('checked')).toBe(false);
           expect(radio.prop('name')).toBe("question_" + defaultProps.question.id);
           expect(radio.prop('value')).toBe(defaultProps.question.options[index].id);
@@ -117,16 +119,37 @@ describe('QuestionForm', () => {
         });
       });
 
+      test('Radios with correct autoFocus when prop autoFocus is true', () => {
+        const autoFocus = true;
+        const question = {...defaultProps.question, ...{type: 'single-choice'}};
+        const radios = getWrapper({autoFocus, canAnswer, question}).find(Radio);
+        expect(radios).toHaveLength(3);
+        radios.forEach((radio, index) => {
+          expect(radio.prop('autoFocus')).toBe(index === 0);
+        });
+      });
+
       test('Checkboxes when question is multiple choice', () => {
         const question = {...defaultProps.question, ...{type: 'multiple-choice'}};
         const checkboxes = getWrapper({canAnswer, question}).find(Checkbox);
         expect(checkboxes).toHaveLength(3);
         checkboxes.forEach((checkbox, index) => {
+          expect(checkbox.prop('autoFocus')).toBe(false);
           expect(checkbox.prop('checked')).toBe(false);
           expect(checkbox.prop('name')).toBe("question_" + defaultProps.question.id);
           expect(checkbox.prop('value')).toBe(defaultProps.question.options[index].id);
           expect(checkbox.prop('onChange')).toBeDefined();
           expect(checkbox.childAt(0).text()).toBe(defaultProps.question.options[index].text.fi);
+        });
+      });
+
+      test('Checkboxes with correct autoFocus when prop autoFocus is true', () => {
+        const autoFocus = true;
+        const question = {...defaultProps.question, ...{type: 'multiple-choice'}};
+        const checkbox = getWrapper({autoFocus, canAnswer, question}).find(Checkbox);
+        expect(checkbox).toHaveLength(3);
+        checkbox.forEach((radio, index) => {
+          expect(radio.prop('autoFocus')).toBe(index === 0);
         });
       });
     });

--- a/__tests__/Utils/section.react-test.js
+++ b/__tests__/Utils/section.react-test.js
@@ -1,5 +1,6 @@
 import {
   checkFormErrors,
+  getFirstUnansweredQuestion,
   hasAnyAnswers,
   hasAnyQuestions,
   hasUserAnsweredAllQuestions,
@@ -228,6 +229,38 @@ describe('section util tests', () => {
     });
     test('returns true when user has answered all questions', () => {
       expect(hasUserAnsweredAllQuestions(userAllAnswers, sectionWithQuestions)).toBe(true);
+    });
+  });
+
+  describe('getFirstUnansweredQuestion', () => {
+    describe('returns null', () => {
+      test('when section has no questions', () => {
+        expect(getFirstUnansweredQuestion(createUser(), sectionEmpty)).toBe(null);
+      });
+
+      test('when section has no unanswered questions', () => {
+        const userWithAnswers = createUser({answered_questions: [1, 2]});
+        expect(getFirstUnansweredQuestion(userWithAnswers, sectionWithQuestions)).toBe(null);
+      });
+    });
+
+    describe('returns first unanswered question', () => {
+      test('when user is anon', () => {
+        expect(getFirstUnansweredQuestion(null, sectionWithQuestions))
+          .toBe(sectionWithQuestions.questions[0]);
+      });
+
+      test('when signed in user has not answered any questions', () => {
+        expect(getFirstUnansweredQuestion(createUser(), sectionWithQuestions))
+          .toBe(sectionWithQuestions.questions[0]);
+      });
+
+      test('when signed in user has answered some questions', () => {
+        expect(getFirstUnansweredQuestion(createUser({answered_questions: [1]}), sectionWithQuestions))
+          .toBe(sectionWithQuestions.questions[1]);
+        expect(getFirstUnansweredQuestion(createUser({answered_questions: [2]}), sectionWithQuestions))
+          .toBe(sectionWithQuestions.questions[0]);
+      });
     });
   });
 });

--- a/src/components/BaseCommentForm.js
+++ b/src/components/BaseCommentForm.js
@@ -15,6 +15,7 @@ import QuestionForm from './QuestionForm';
 import {localizedNotifyError} from "../utils/notify";
 import {
   checkFormErrors,
+  getFirstUnansweredQuestion,
   getSectionCommentingErrorMessage,
   hasAnyAnswers,
   hasAnyQuestions,
@@ -491,6 +492,7 @@ export class BaseCommentForm extends React.Component {
     const hasQuestions = hasAnyQuestions(section);
     const userAnsweredAllQuestions = loggedIn && hasUserAnsweredAllQuestions(user, section);
     const commentRequired = isCommentRequired(hasQuestions, isReply, userAnsweredAllQuestions);
+    const firstUnansweredQuestion = getFirstUnansweredQuestion(user, section);
 
     return (
       <div className="comment-form">
@@ -518,6 +520,8 @@ export class BaseCommentForm extends React.Component {
               return canShowQuestionForm
                 ? (
                   <QuestionForm
+                    // give focus when there are unanswered questions
+                    autoFocus={!!firstUnansweredQuestion && firstUnansweredQuestion.id === question.id}
                     key={question.id}
                     canAnswer={canComment}
                     answers={answers.find(answer => answer.question === question.id)}
@@ -547,7 +551,8 @@ export class BaseCommentForm extends React.Component {
             }
           </div>
           <FormControl
-            autoFocus
+            // set focus when there are no questions before to be answered
+            autoFocus={isReply || !firstUnansweredQuestion}
             componentClass="textarea"
             value={this.state.commentText}
             onChange={this.handleTextChange.bind(this)}

--- a/src/components/QuestionForm/index.js
+++ b/src/components/QuestionForm/index.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import getAttr from '../../utils/getAttr';
 
-const QuestionForm = ({question, lang, onChange, answers, canAnswer}) => {
+const QuestionForm = ({autoFocus, question, lang, onChange, answers, canAnswer}) => {
   return (
     <FormGroup
       className="question-form-group"
@@ -18,10 +18,11 @@ const QuestionForm = ({question, lang, onChange, answers, canAnswer}) => {
             <FormattedMessage id={question.type === 'multiple-choice' ? 'questionHelpMulti' : 'questionHelpSingle'} />
           </HelpBlock>
         </legend>
-        {canAnswer && question.type === 'single-choice' && question.options.map((option) => {
+        {canAnswer && question.type === 'single-choice' && question.options.map((option, index) => {
           const optionContent = getAttr(option.text, lang);
           return (
             <Radio
+              autoFocus={autoFocus && index === 0}
               checked={answers && answers.answers.includes(option.id)}
               key={option.id}
               name={`question_${question.id}`}
@@ -32,8 +33,9 @@ const QuestionForm = ({question, lang, onChange, answers, canAnswer}) => {
             </Radio>
           );
         })}
-        {canAnswer && question.type === 'multiple-choice' && question.options.map((option) => (
+        {canAnswer && question.type === 'multiple-choice' && question.options.map((option, index) => (
           <Checkbox
+            autoFocus={autoFocus && index === 0}
             checked={answers && answers.answers.includes(option.id)}
             key={option.id}
             name={`question_${question.id}`}
@@ -50,6 +52,7 @@ const QuestionForm = ({question, lang, onChange, answers, canAnswer}) => {
 };
 
 QuestionForm.propTypes = {
+  autoFocus: PropTypes.bool,
   question: PropTypes.object,
   lang: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/utils/section.js
+++ b/src/utils/section.js
@@ -108,6 +108,31 @@ export function hasUserAnsweredAllQuestions(user, section) {
   return false;
 }
 
+/**
+ * Returns the first unanswered section question or null when there are no
+ * unanswered questions.
+ * @param {Object} user object containing user data
+ * @param {Object} section object containing section data
+ * @returns {Object|null} first unanswered question object or null
+ */
+export function getFirstUnansweredQuestion(user, section) {
+  if (hasAnyQuestions(section)) {
+    const {questions} = section;
+    // anon users and users without answers
+    if (!user || !hasUserAnsweredQuestions(user)) {
+      return questions[0];
+    } else if (hasUserAnsweredQuestions(user)) {
+      const answeredQuestions = user.answered_questions;
+      for (let index = 0; index < questions.length; index += 1) {
+        if (!answeredQuestions.includes(questions[index].id)) {
+          return questions[index];
+        }
+      }
+    }
+  }
+  return null;
+}
+
 export const isMainSection = (section) => {
   return section.type === SectionTypes.MAIN;
 };


### PR DESCRIPTION
# Hearing section comment autofocus when questions exist

## When section has questions, autofocus is given to the first unanswered question instead of the comment textarea. This fixes the issue of questions being jumped over unintentionally.

### [Related Trello card](https://trello.com/c/rTtr303g)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Comment form autofocus
 1. src/components/BaseCommentForm.js
     * autofocus is given to the first unanswered question or to the comment text field when there are no unanswered questions
   
 2. src/components/QuestionForm/index.js
     * autofocus is given to the first question option when question autofocus prop is true
    
 3. src/utils/section.js
     * new util function `getFirstUnansweredQuestion` to retrieve the first unanswered section question