### PR TITLE
Fix to hearing crash when scrolling comments

### DIFF
--- a/src/components/Hearing/CommentList/index.js
+++ b/src/components/Hearing/CommentList/index.js
@@ -24,7 +24,7 @@ export class CommentList extends React.Component {
          * replies made to that comment, boolean false added when replies have been successfully fetched.
          * @type {undefined | boolean}
          */
-        const previousLoadingState = prevProps.comments[index].loadingSubComments;
+        const previousLoadingState = prevProps.comments[index] && prevProps.comments[index].loadingSubComments;
         const currentLoadingState = curr.loadingSubComments;
         // if previously loading and now not loading -> true so the replies are visible once mounted, otherwise false.
         const nextLoadingState = (previousLoadingState && !currentLoadingState) || false;


### PR DESCRIPTION
# Fix to hearing page crash when scrolling the comments section.

#### If a hearing had 100+ comments and a user tried to rapidly scroll to the bottom of the page and up again caused the page to crash. This happened because the next 100 comments were being loaded while the CommentList component tried to access  a value at an index that didn't exist anymore. This fix simply checks if the index exists before trying to access it.

[Trello card for this fix.](https://trello.com/c/vlfz3Dl2/178-kuulemisen-sivu-kaatuu-jos-kommentteja-selaa-nopeasti)

-----------------------------------------------------------------------------------------------
Changes:
- **src/components/Hearing/CommentList/index.js:**
Check if `prevProps.comments[index]` exists before trying to access `prevProps.comments[index].loadingSubComments`.
